### PR TITLE
[KMP-13] iOS DI bootstrapping — initKoin() accessible from Swift

### DIFF
--- a/di/build.gradle.kts
+++ b/di/build.gradle.kts
@@ -10,10 +10,20 @@ kotlin {
     iosSimulatorArm64()
 
     sourceSets {
+        val commonMain by getting {
+            dependencies {
+                implementation(libs.koin.core)
+                implementation(libs.kotlinx.coroutines.core)
+            }
+        }
+        val iosMain by creating {
+            dependsOn(getByName("commonMain"))
+        }
+        val iosArm64Main by getting { dependsOn(iosMain) }
+        val iosSimulatorArm64Main by getting { dependsOn(iosMain) }
         val androidMain by getting {
             dependencies {
                 implementation(libs.androidx.core.ktx)
-                implementation(libs.kotlinx.coroutines.core)
                 implementation(libs.kotlinx.coroutines.android)
                 implementation(libs.androidx.room.runtime)
                 implementation(libs.koin.android)
@@ -28,11 +38,13 @@ kotlin {
 }
 
 dependencies {
-    add("androidMainImplementation", project(":viewmodel"))
-    add("androidMainImplementation", project(":usecase"))
-    add("androidMainImplementation", project(":data:core"))
-    add("androidMainImplementation", project(":data:local"))
-    add("androidMainImplementation", project(":data:remote"))
+    // Business-logic modules — all are KMP-compatible (commonMain or expect/actual)
+    add("commonMainImplementation", project(":domain"))
+    add("commonMainImplementation", project(":usecase"))
+    add("commonMainImplementation", project(":data:core"))
+    add("commonMainImplementation", project(":data:local"))
+    add("commonMainImplementation", project(":data:remote"))
+    add("commonMainImplementation", project(":viewmodel"))
 }
 
 android {

--- a/di/src/commonMain/kotlin/com/jesuslcorominas/teamflowmanager/di/InitKoin.kt
+++ b/di/src/commonMain/kotlin/com/jesuslcorominas/teamflowmanager/di/InitKoin.kt
@@ -1,0 +1,35 @@
+package com.jesuslcorominas.teamflowmanager.di
+
+import com.jesuslcorominas.teamflowmanager.data.core.di.dataCoreModule
+import com.jesuslcorominas.teamflowmanager.data.local.di.dataLocalModule
+import com.jesuslcorominas.teamflowmanager.data.remote.di.dataRemoteModule
+import com.jesuslcorominas.teamflowmanager.usecase.di.useCaseModule
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import org.koin.core.KoinApplication
+import org.koin.core.context.startKoin
+import org.koin.core.module.Module
+import org.koin.dsl.module
+
+/**
+ * Base business-logic Koin module shared by all platforms.
+ * Includes data layers + use cases + a default CoroutineDispatcher.
+ */
+val businessLogicModule: Module = module {
+    includes(
+        dataLocalModule,
+        dataCoreModule,
+        dataRemoteModule,
+        useCaseModule,
+    )
+    single<CoroutineDispatcher> { Dispatchers.Default }
+}
+
+/**
+ * Starts Koin with the shared business-logic module plus any platform-specific modules.
+ * Called from iOS Swift code (and reusable for JVM/Desktop in the future).
+ */
+fun initKoin(additionalModules: List<Module> = emptyList()): KoinApplication =
+    startKoin {
+        modules(listOf(businessLogicModule) + additionalModules)
+    }

--- a/di/src/iosMain/kotlin/com/jesuslcorominas/teamflowmanager/di/IosModule.kt
+++ b/di/src/iosMain/kotlin/com/jesuslcorominas/teamflowmanager/di/IosModule.kt
@@ -1,0 +1,86 @@
+package com.jesuslcorominas.teamflowmanager.di
+
+import com.jesuslcorominas.teamflowmanager.domain.analytics.AnalyticsTracker
+import com.jesuslcorominas.teamflowmanager.domain.analytics.CrashReporter
+import com.jesuslcorominas.teamflowmanager.domain.utils.TimeProvider
+import com.jesuslcorominas.teamflowmanager.viewmodel.LoginViewModel
+import com.jesuslcorominas.teamflowmanager.viewmodel.MatchListViewModel
+import com.jesuslcorominas.teamflowmanager.viewmodel.SplashViewModel
+import kotlinx.cinterop.ExperimentalForeignApi
+import org.koin.core.KoinApplication
+import org.koin.dsl.module
+import platform.posix.time
+
+/**
+ * iOS-specific Koin module that provides:
+ * - No-op AnalyticsTracker and CrashReporter (Firebase Analytics/Crashlytics for iOS is KMP-15+)
+ * - iOS TimeProvider backed by NSDate
+ * - Factory registrations for the three ViewModels needed by the iOS Phase 2 MVP
+ */
+val iosModule = module {
+    single<AnalyticsTracker> { NoOpAnalyticsTracker() }
+    single<CrashReporter> { NoOpCrashReporter() }
+    single<TimeProvider> { IosTimeProvider() }
+
+    // ViewModels registered as factory (no viewModel {} DSL on iOS)
+    factory {
+        SplashViewModel(
+            getTeam = get(),
+            getCurrentUser = get(),
+            getUserClubMembership = get(),
+            synchronizeTimeUseCase = get(),
+        )
+    }
+    factory {
+        LoginViewModel(
+            signInWithGoogleUseCase = get(),
+            analyticsTracker = get(),
+        )
+    }
+    factory {
+        MatchListViewModel(
+            getAllMatchesUseCase = get(),
+            deleteMatchUseCase = get(),
+            resumeMatchUseCase = get(),
+            archiveMatchUseCase = get(),
+            synchronizeTimeUseCase = get(),
+            timeProvider = get(),
+            analyticsTracker = get(),
+            crashReporter = get(),
+        )
+    }
+}
+
+/**
+ * Entry point for iOS Swift code to initialise Koin.
+ * Call from AppDelegate or @main struct before accessing any use cases or ViewModels.
+ *
+ * Swift usage:
+ *   import TeamflowmanagerDi
+ *   IosModuleKt.doInitKoinIos()
+ */
+fun initKoinIos(): KoinApplication = initKoin(additionalModules = listOf(iosModule))
+
+// ── Private iOS stub implementations ─────────────────────────────────────────
+
+@OptIn(ExperimentalForeignApi::class)
+private class IosTimeProvider : TimeProvider {
+    override fun getCurrentTime(): Long = time(null).toLong() * 1000L
+    override suspend fun synchronize() = Unit
+    override fun getOffset(): Long = 0L
+}
+
+private class NoOpAnalyticsTracker : AnalyticsTracker {
+    override fun logEvent(eventName: String, params: Map<String, Any>) = Unit
+    override fun logScreenView(screenName: String, screenClass: String?) = Unit
+    override fun setUserId(userId: String?) = Unit
+    override fun setUserProperty(key: String, value: String?) = Unit
+}
+
+private class NoOpCrashReporter : CrashReporter {
+    override fun recordException(throwable: Throwable) = Unit
+    override fun log(message: String) = Unit
+    override fun setCustomKey(key: String, value: String) = Unit
+    override fun setCustomKey(key: String, value: Int) = Unit
+    override fun setCustomKey(key: String, value: Boolean) = Unit
+}


### PR DESCRIPTION
## Summary

- Adds `commonMain` sourceSet to `:di` with `koin-core` and `kotlinx-coroutines-core`
- Adds `iosMain` intermediate sourceSet (same pattern as `:data:remote`)
- Moves all business-logic project dependencies (`domain`, `usecase`, `data:core`, `data:local`, `data:remote`, `viewmodel`) from `androidMain` to `commonMain`
- Creates `InitKoin.kt` (commonMain): `businessLogicModule` + `initKoin(additionalModules)` entry point shared by all platforms
- Creates `IosModule.kt` (iosMain):
  - `NoOpAnalyticsTracker` and `NoOpCrashReporter` (Firebase Analytics/Crashlytics deferred to KMP-15+)
  - `IosTimeProvider` backed by `platform.posix.time`
  - `factory {}` registrations for `SplashViewModel`, `LoginViewModel`, `MatchListViewModel`
  - `initKoinIos()` function callable from Swift

## Swift usage

```swift
import TeamflowmanagerDi

// In AppDelegate.application(_:didFinishLaunchingWithOptions:) or @main init
IosModuleKt.doInitKoinIos()
```

After this, ViewModels can be retrieved via `KoinComponent` or direct `get()` calls from Swift.

## Architecture

- `businessLogicModule` (commonMain): composes platform-agnostic modules — uses `expect/actual` for `dataLocalModule` and `dataRemoteModule` (each resolves to their iosMain actual automatically)
- `iosModule` (iosMain): platform-specific stubs + ViewModel factory registrations
- `initKoinIos()` calls `initKoin(listOf(iosModule))` — composable for future extension

## Test plan

- [x] `./gradlew :di:compileKotlinIosSimulatorArm64` passes
- [x] `./gradlew :di:compileDebugKotlinAndroid` passes
- [x] `./gradlew :app:assembleDevDebug` passes

Closes #253

🤖 Generated with [Claude Code](https://claude.com/claude-code)