### PR TITLE
[KMP-21] Migrate secondary screens to :shared-ui (CMP)

### DIFF
--- a/shared-ui/build.gradle.kts
+++ b/shared-ui/build.gradle.kts
@@ -17,6 +17,7 @@ kotlin {
                 implementation(compose.runtime)
                 implementation(compose.foundation)
                 implementation(compose.material3)
+                implementation(compose.materialIconsExtended)
                 implementation(compose.ui)
                 implementation(compose.components.resources)
                 implementation(libs.kotlinx.coroutines.core)
@@ -28,7 +29,6 @@ kotlin {
             dependencies {
                 implementation(libs.androidx.lifecycle.runtime.ktx)
                 implementation(libs.kotlinx.coroutines.android)
-                implementation(libs.androidx.material.icons.extended)
                 implementation(libs.androidx.compose.animation)
                 implementation(libs.androidx.compose.ui.tooling.preview)
                 implementation(libs.androidx.activity.compose)

--- a/shared-ui/src/androidMain/kotlin/com/jesuslcorominas/teamflowmanager/ui/settings/UserAvatar.kt
+++ b/shared-ui/src/androidMain/kotlin/com/jesuslcorominas/teamflowmanager/ui/settings/UserAvatar.kt
@@ -1,0 +1,40 @@
+package com.jesuslcorominas.teamflowmanager.ui.settings
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Person
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
+import coil.compose.AsyncImage
+
+@Composable
+actual fun UserAvatar(photoUrl: String?, modifier: Modifier) {
+    if (photoUrl != null) {
+        AsyncImage(
+            model = photoUrl,
+            contentDescription = null,
+            modifier = modifier.clip(CircleShape),
+            contentScale = ContentScale.Crop,
+        )
+    } else {
+        Box(
+            modifier = modifier
+                .clip(CircleShape)
+                .background(MaterialTheme.colorScheme.primaryContainer),
+            contentAlignment = Alignment.Center,
+        ) {
+            Icon(
+                imageVector = Icons.Outlined.Person,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onPrimaryContainer,
+            )
+        }
+    }
+}

--- a/shared-ui/src/androidMain/kotlin/com/jesuslcorominas/teamflowmanager/ui/util/DateFormatter.kt
+++ b/shared-ui/src/androidMain/kotlin/com/jesuslcorominas/teamflowmanager/ui/util/DateFormatter.kt
@@ -1,0 +1,23 @@
+package com.jesuslcorominas.teamflowmanager.ui.util
+
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+
+actual object DateFormatter {
+    private val dateFormat = SimpleDateFormat("dd/MM/yyyy", Locale.getDefault())
+    private val timeFormat = SimpleDateFormat("HH:mm", Locale.getDefault())
+    private val dateTimeFormat = SimpleDateFormat("dd/MM/yyyy HH:mm", Locale.getDefault())
+
+    actual fun formatDate(timestamp: Long): String = dateFormat.format(Date(timestamp))
+
+    actual fun formatTime(timestamp: Long): String = timeFormat.format(Date(timestamp))
+
+    actual fun formatDateTime(timestamp: Long): String = dateTimeFormat.format(Date(timestamp))
+
+    actual fun formatTimeOfDay(timeOfDayMillis: Long): String {
+        val hours = (timeOfDayMillis / (60 * 60 * 1000)) % 24
+        val minutes = (timeOfDayMillis / (60 * 1000)) % 60
+        return String.format(Locale.getDefault(), "%02d:%02d", hours, minutes)
+    }
+}

--- a/shared-ui/src/commonMain/composeResources/values/strings.xml
+++ b/shared-ui/src/commonMain/composeResources/values/strings.xml
@@ -144,13 +144,13 @@
     <string name="team_creation_permission_error_message">Only club Presidents can create teams. Please contact your club President to create a team.</string>
 
     <!-- Team Invitation -->
-    <string name="accepting_team_invitation">Procesando invitación…</string>
-    <string name="redirecting_to_login">Por favor inicia sesión para aceptar la invitación…</string>
-    <string name="team_invitation_accepted">¡Invitación Aceptada!</string>
-    <string name="team_invitation_success_message">Ahora eres el entrenador de %1$s</string>
-    <string name="team_invitation_error">Error al Aceptar Invitación</string>
-    <string name="go_to_team">Ir al Equipo</string>
-    <string name="go_to_teams">Ir a Equipos</string>
+    <string name="accepting_team_invitation">Processing invitation…</string>
+    <string name="redirecting_to_login">Please sign in to accept the invitation…</string>
+    <string name="team_invitation_accepted">Invitation Accepted!</string>
+    <string name="team_invitation_success_message">You are now the coach of %1$s</string>
+    <string name="team_invitation_error">Error Accepting Invitation</string>
+    <string name="go_to_team">Go to Team</string>
+    <string name="go_to_teams">Go to Teams</string>
     <string name="self_assign_as_coach_button">Assign me as Coach</string>
     <string name="self_assign_as_coach_success">Te has asignado como Coach del equipo</string>
     <string name="self_assign_as_coach_error">Error al asignarte como Coach. Por favor, inténtalo de nuevo.</string>

--- a/shared-ui/src/commonMain/kotlin/com/jesuslcorominas/teamflowmanager/ui/invitation/AcceptTeamInvitationScreen.kt
+++ b/shared-ui/src/commonMain/kotlin/com/jesuslcorominas/teamflowmanager/ui/invitation/AcceptTeamInvitationScreen.kt
@@ -1,0 +1,168 @@
+package com.jesuslcorominas.teamflowmanager.ui.invitation
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.CheckCircle
+import androidx.compose.material.icons.filled.Error
+import androidx.compose.material3.Button
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import com.jesuslcorominas.teamflowmanager.viewmodel.AcceptTeamInvitationState
+import com.jesuslcorominas.teamflowmanager.viewmodel.AcceptTeamInvitationViewModel
+import org.jetbrains.compose.resources.stringResource
+import org.koin.compose.viewmodel.koinViewModel
+import org.koin.core.parameter.parametersOf
+import teamflowmanager.shared_ui.generated.resources.Res
+import teamflowmanager.shared_ui.generated.resources.accepting_team_invitation
+import teamflowmanager.shared_ui.generated.resources.go_to_team
+import teamflowmanager.shared_ui.generated.resources.go_to_teams
+import teamflowmanager.shared_ui.generated.resources.redirecting_to_login
+import teamflowmanager.shared_ui.generated.resources.retry
+import teamflowmanager.shared_ui.generated.resources.team_invitation_accepted
+import teamflowmanager.shared_ui.generated.resources.team_invitation_error
+import teamflowmanager.shared_ui.generated.resources.team_invitation_success_message
+
+@Composable
+fun AcceptTeamInvitationScreen(
+    teamId: String?,
+    onNavigateToLogin: (String) -> Unit,
+    onNavigateToTeam: () -> Unit,
+    onNavigateToTeams: () -> Unit,
+    viewModel: AcceptTeamInvitationViewModel = koinViewModel(parameters = { parametersOf(teamId) }),
+) {
+    val state by viewModel.state.collectAsState()
+
+    LaunchedEffect(state) {
+        if (state is AcceptTeamInvitationState.NotAuthenticated) {
+            val id = (state as AcceptTeamInvitationState.NotAuthenticated).teamId
+            onNavigateToLogin(id)
+        }
+    }
+
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(16.dp),
+        contentAlignment = Alignment.Center,
+    ) {
+        when (val currentState = state) {
+            is AcceptTeamInvitationState.Loading -> {
+                Column(
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    verticalArrangement = Arrangement.spacedBy(16.dp),
+                ) {
+                    CircularProgressIndicator()
+                    Text(
+                        text = stringResource(Res.string.accepting_team_invitation),
+                        style = MaterialTheme.typography.bodyLarge,
+                        textAlign = TextAlign.Center,
+                    )
+                }
+            }
+
+            is AcceptTeamInvitationState.Success -> {
+                Column(
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    verticalArrangement = Arrangement.spacedBy(24.dp),
+                ) {
+                    Icon(
+                        imageVector = Icons.Default.CheckCircle,
+                        contentDescription = null,
+                        modifier = Modifier.size(64.dp),
+                        tint = MaterialTheme.colorScheme.primary,
+                    )
+                    Text(
+                        text = stringResource(Res.string.team_invitation_accepted),
+                        style = MaterialTheme.typography.headlineMedium,
+                        textAlign = TextAlign.Center,
+                    )
+                    Text(
+                        text = stringResource(Res.string.team_invitation_success_message, currentState.team.name),
+                        style = MaterialTheme.typography.bodyLarge,
+                        textAlign = TextAlign.Center,
+                    )
+                    Button(
+                        onClick = onNavigateToTeam,
+                        modifier = Modifier.fillMaxWidth(),
+                    ) {
+                        Text(stringResource(Res.string.go_to_team))
+                    }
+                }
+            }
+
+            is AcceptTeamInvitationState.Error -> {
+                Column(
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    verticalArrangement = Arrangement.spacedBy(24.dp),
+                ) {
+                    Icon(
+                        imageVector = Icons.Default.Error,
+                        contentDescription = null,
+                        modifier = Modifier.size(64.dp),
+                        tint = MaterialTheme.colorScheme.error,
+                    )
+                    Text(
+                        text = stringResource(Res.string.team_invitation_error),
+                        style = MaterialTheme.typography.headlineMedium,
+                        textAlign = TextAlign.Center,
+                    )
+                    Text(
+                        text = currentState.message,
+                        style = MaterialTheme.typography.bodyLarge,
+                        textAlign = TextAlign.Center,
+                        color = MaterialTheme.colorScheme.error,
+                    )
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.spacedBy(16.dp),
+                    ) {
+                        OutlinedButton(
+                            onClick = onNavigateToTeams,
+                            modifier = Modifier.weight(1f),
+                        ) {
+                            Text(stringResource(Res.string.go_to_teams))
+                        }
+                        Button(
+                            onClick = { viewModel.retry() },
+                            modifier = Modifier.weight(1f),
+                        ) {
+                            Text(stringResource(Res.string.retry))
+                        }
+                    }
+                }
+            }
+
+            is AcceptTeamInvitationState.NotAuthenticated -> {
+                Column(
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    verticalArrangement = Arrangement.spacedBy(16.dp),
+                ) {
+                    CircularProgressIndicator()
+                    Text(
+                        text = stringResource(Res.string.redirecting_to_login),
+                        style = MaterialTheme.typography.bodyLarge,
+                        textAlign = TextAlign.Center,
+                    )
+                }
+            }
+        }
+    }
+}

--- a/shared-ui/src/commonMain/kotlin/com/jesuslcorominas/teamflowmanager/ui/matches/ArchivedMatchesScreen.kt
+++ b/shared-ui/src/commonMain/kotlin/com/jesuslcorominas/teamflowmanager/ui/matches/ArchivedMatchesScreen.kt
@@ -1,0 +1,58 @@
+package com.jesuslcorominas.teamflowmanager.ui.matches
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import com.jesuslcorominas.teamflowmanager.domain.analytics.ScreenName
+import com.jesuslcorominas.teamflowmanager.domain.model.Match
+import com.jesuslcorominas.teamflowmanager.ui.analytics.TrackScreenView
+import com.jesuslcorominas.teamflowmanager.ui.components.EmptyContent
+import com.jesuslcorominas.teamflowmanager.ui.components.Loading
+import com.jesuslcorominas.teamflowmanager.ui.matches.card.PlayedMatchCard
+import com.jesuslcorominas.teamflowmanager.ui.theme.TFMSpacing
+import com.jesuslcorominas.teamflowmanager.viewmodel.ArchivedMatchesUiState
+import com.jesuslcorominas.teamflowmanager.viewmodel.ArchivedMatchesViewModel
+import org.jetbrains.compose.resources.stringResource
+import org.koin.compose.viewmodel.koinViewModel
+import teamflowmanager.shared_ui.generated.resources.Res
+import teamflowmanager.shared_ui.generated.resources.no_archived_matches
+
+@Composable
+fun ArchivedMatchesScreen(
+    onNavigateToMatchSummary: (Match) -> Unit,
+    viewModel: ArchivedMatchesViewModel = koinViewModel(),
+) {
+    TrackScreenView(screenName = ScreenName.ARCHIVED_MATCHES, screenClass = "ArchivedMatchesScreen")
+
+    val uiState by viewModel.uiState.collectAsState()
+
+    Box(modifier = Modifier.fillMaxSize()) {
+        when (val state = uiState) {
+            is ArchivedMatchesUiState.Loading -> Loading()
+            is ArchivedMatchesUiState.Empty -> EmptyContent(stringResource(Res.string.no_archived_matches))
+            is ArchivedMatchesUiState.Success -> {
+                LazyColumn(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .padding(TFMSpacing.spacing04),
+                    verticalArrangement = Arrangement.spacedBy(TFMSpacing.spacing02),
+                ) {
+                    items(state.matches) { match ->
+                        PlayedMatchCard(
+                            match = match,
+                            onNavigateToDetail = { onNavigateToMatchSummary(match) },
+                            onAction = { viewModel.unarchiveMatch(match.id) },
+                        )
+                    }
+                }
+            }
+        }
+    }
+}

--- a/shared-ui/src/commonMain/kotlin/com/jesuslcorominas/teamflowmanager/ui/matches/card/PlayedMatchCard.kt
+++ b/shared-ui/src/commonMain/kotlin/com/jesuslcorominas/teamflowmanager/ui/matches/card/PlayedMatchCard.kt
@@ -1,0 +1,87 @@
+package com.jesuslcorominas.teamflowmanager.ui.matches.card
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Archive
+import androidx.compose.material.icons.filled.Unarchive
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import com.jesuslcorominas.teamflowmanager.domain.model.Match
+import com.jesuslcorominas.teamflowmanager.ui.components.AppTitle
+import com.jesuslcorominas.teamflowmanager.ui.components.card.AppCard
+import com.jesuslcorominas.teamflowmanager.ui.theme.TFMSpacing
+import com.jesuslcorominas.teamflowmanager.ui.util.DateFormatter
+import org.jetbrains.compose.resources.stringResource
+import teamflowmanager.shared_ui.generated.resources.Res
+import teamflowmanager.shared_ui.generated.resources.archive_match
+import teamflowmanager.shared_ui.generated.resources.match_score
+import teamflowmanager.shared_ui.generated.resources.unarchive_match
+
+@Composable
+fun PlayedMatchCard(
+    modifier: Modifier = Modifier,
+    match: Match,
+    onNavigateToDetail: () -> Unit = {},
+    onAction: () -> Unit = {},
+) {
+    AppCard(
+        modifier = modifier
+            .fillMaxWidth()
+            .clickable { onNavigateToDetail() },
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(TFMSpacing.spacing04),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Column(modifier = Modifier.weight(1f)) {
+                AppTitle(title = match.opponent)
+                Spacer(modifier = Modifier.height(TFMSpacing.spacing01))
+                Text(
+                    text = match.location,
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+
+                match.dateTime?.let {
+                    Spacer(modifier = Modifier.height(TFMSpacing.spacing01))
+                    Text(
+                        text = DateFormatter.formatDateTime(it),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            }
+
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Text(
+                    text = stringResource(Res.string.match_score, match.goals, match.opponentGoals),
+                    style = MaterialTheme.typography.titleLarge,
+                    fontWeight = FontWeight.Bold,
+                )
+
+                IconButton(onClick = onAction) {
+                    Icon(
+                        imageVector = if (match.archived) Icons.Default.Unarchive else Icons.Default.Archive,
+                        contentDescription = stringResource(if (match.archived) Res.string.unarchive_match else Res.string.archive_match),
+                    )
+                }
+            }
+        }
+    }
+}

--- a/shared-ui/src/commonMain/kotlin/com/jesuslcorominas/teamflowmanager/ui/settings/SettingsScreen.kt
+++ b/shared-ui/src/commonMain/kotlin/com/jesuslcorominas/teamflowmanager/ui/settings/SettingsScreen.kt
@@ -1,0 +1,161 @@
+package com.jesuslcorominas.teamflowmanager.ui.settings
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.outlined.Logout
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.jesuslcorominas.teamflowmanager.domain.analytics.ScreenName
+import com.jesuslcorominas.teamflowmanager.domain.model.User
+import com.jesuslcorominas.teamflowmanager.ui.analytics.TrackScreenView
+import com.jesuslcorominas.teamflowmanager.ui.theme.TFMSpacing
+import com.jesuslcorominas.teamflowmanager.viewmodel.SettingsViewModel
+import org.jetbrains.compose.resources.stringResource
+import org.koin.compose.viewmodel.koinViewModel
+import teamflowmanager.shared_ui.generated.resources.Res
+import teamflowmanager.shared_ui.generated.resources.cancel
+import teamflowmanager.shared_ui.generated.resources.settings_account_section
+import teamflowmanager.shared_ui.generated.resources.sign_out
+import teamflowmanager.shared_ui.generated.resources.sign_out_message
+import teamflowmanager.shared_ui.generated.resources.sign_out_title
+import teamflowmanager.shared_ui.generated.resources.user_name_unknown
+
+@Composable
+fun SettingsScreen(
+    viewModel: SettingsViewModel = koinViewModel(),
+    onSignOut: () -> Unit = {},
+) {
+    TrackScreenView(screenName = ScreenName.SETTINGS, screenClass = "SettingsScreen")
+
+    val currentUser by viewModel.currentUser.collectAsState()
+    val signOutComplete by viewModel.signOutComplete.collectAsState()
+    var showSignOutDialog by remember { mutableStateOf(false) }
+
+    LaunchedEffect(signOutComplete) {
+        if (signOutComplete) {
+            viewModel.clearSignOutComplete()
+            onSignOut()
+        }
+    }
+
+    if (showSignOutDialog) {
+        AlertDialog(
+            onDismissRequest = { showSignOutDialog = false },
+            icon = {
+                Icon(
+                    imageVector = Icons.AutoMirrored.Outlined.Logout,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.error,
+                )
+            },
+            title = { Text(text = stringResource(Res.string.sign_out_title)) },
+            text = { Text(text = stringResource(Res.string.sign_out_message)) },
+            confirmButton = {
+                TextButton(
+                    onClick = {
+                        viewModel.signOut()
+                        showSignOutDialog = false
+                    },
+                ) {
+                    Text(stringResource(Res.string.sign_out))
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { showSignOutDialog = false }) {
+                    Text(stringResource(Res.string.cancel))
+                }
+            },
+        )
+    }
+
+    Surface(
+        modifier = Modifier.fillMaxSize(),
+        color = MaterialTheme.colorScheme.background,
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(TFMSpacing.spacing04),
+        ) {
+            Text(
+                text = stringResource(Res.string.settings_account_section),
+                style = MaterialTheme.typography.titleMedium,
+                color = MaterialTheme.colorScheme.primary,
+                modifier = Modifier.padding(horizontal = TFMSpacing.spacing02),
+            )
+
+            Spacer(modifier = Modifier.height(TFMSpacing.spacing02))
+
+            currentUser?.let { user ->
+                UserAccountItem(
+                    user = user,
+                    onClick = { showSignOutDialog = true },
+                )
+            }
+
+            Spacer(modifier = Modifier.height(TFMSpacing.spacing06))
+        }
+    }
+}
+
+@Composable
+private fun UserAccountItem(
+    user: User,
+    onClick: () -> Unit,
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(onClick = onClick)
+            .padding(TFMSpacing.spacing02),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        UserAvatar(
+            photoUrl = user.photoUrl,
+            modifier = Modifier.size(48.dp),
+        )
+
+        Spacer(modifier = Modifier.width(TFMSpacing.spacing04))
+
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = user.displayName ?: stringResource(Res.string.user_name_unknown),
+                style = MaterialTheme.typography.bodyLarge,
+            )
+            Text(
+                text = user.email ?: "",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+
+        Icon(
+            imageVector = Icons.AutoMirrored.Outlined.Logout,
+            contentDescription = stringResource(Res.string.sign_out),
+            tint = MaterialTheme.colorScheme.error,
+        )
+    }
+}

--- a/shared-ui/src/commonMain/kotlin/com/jesuslcorominas/teamflowmanager/ui/settings/UserAvatar.kt
+++ b/shared-ui/src/commonMain/kotlin/com/jesuslcorominas/teamflowmanager/ui/settings/UserAvatar.kt
@@ -1,0 +1,7 @@
+package com.jesuslcorominas.teamflowmanager.ui.settings
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+
+@Composable
+expect fun UserAvatar(photoUrl: String?, modifier: Modifier = Modifier)

--- a/shared-ui/src/commonMain/kotlin/com/jesuslcorominas/teamflowmanager/ui/util/DateFormatter.kt
+++ b/shared-ui/src/commonMain/kotlin/com/jesuslcorominas/teamflowmanager/ui/util/DateFormatter.kt
@@ -1,0 +1,8 @@
+package com.jesuslcorominas.teamflowmanager.ui.util
+
+expect object DateFormatter {
+    fun formatDate(timestamp: Long): String
+    fun formatTime(timestamp: Long): String
+    fun formatDateTime(timestamp: Long): String
+    fun formatTimeOfDay(timeOfDayMillis: Long): String
+}

--- a/shared-ui/src/iosMain/kotlin/com/jesuslcorominas/teamflowmanager/ui/settings/UserAvatar.kt
+++ b/shared-ui/src/iosMain/kotlin/com/jesuslcorominas/teamflowmanager/ui/settings/UserAvatar.kt
@@ -1,0 +1,29 @@
+package com.jesuslcorominas.teamflowmanager.ui.settings
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Person
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+
+@Composable
+actual fun UserAvatar(photoUrl: String?, modifier: Modifier) {
+    Box(
+        modifier = modifier
+            .clip(CircleShape)
+            .background(MaterialTheme.colorScheme.primaryContainer),
+        contentAlignment = Alignment.Center,
+    ) {
+        Icon(
+            imageVector = Icons.Outlined.Person,
+            contentDescription = null,
+            tint = MaterialTheme.colorScheme.onPrimaryContainer,
+        )
+    }
+}

--- a/shared-ui/src/iosMain/kotlin/com/jesuslcorominas/teamflowmanager/ui/util/DateFormatter.kt
+++ b/shared-ui/src/iosMain/kotlin/com/jesuslcorominas/teamflowmanager/ui/util/DateFormatter.kt
@@ -1,0 +1,29 @@
+package com.jesuslcorominas.teamflowmanager.ui.util
+
+import platform.Foundation.NSDate
+import platform.Foundation.NSDateFormatter
+import platform.Foundation.NSLocale
+import platform.Foundation.currentLocale
+import platform.Foundation.dateWithTimeIntervalSince1970
+
+actual object DateFormatter {
+    private fun formatter(format: String): NSDateFormatter = NSDateFormatter().apply {
+        dateFormat = format
+        locale = NSLocale.currentLocale
+    }
+
+    actual fun formatDate(timestamp: Long): String =
+        formatter("dd/MM/yyyy").stringFromDate(NSDate.dateWithTimeIntervalSince1970(timestamp / 1000.0))
+
+    actual fun formatTime(timestamp: Long): String =
+        formatter("HH:mm").stringFromDate(NSDate.dateWithTimeIntervalSince1970(timestamp / 1000.0))
+
+    actual fun formatDateTime(timestamp: Long): String =
+        formatter("dd/MM/yyyy HH:mm").stringFromDate(NSDate.dateWithTimeIntervalSince1970(timestamp / 1000.0))
+
+    actual fun formatTimeOfDay(timeOfDayMillis: Long): String {
+        val hours = (timeOfDayMillis / (60 * 60 * 1000)) % 24
+        val minutes = (timeOfDayMillis / (60 * 1000)) % 60
+        return "${hours.toString().padStart(2, '0')}:${minutes.toString().padStart(2, '0')}"
+    }
+}


### PR DESCRIPTION
## Summary
- Migrated `SettingsScreen`, `ArchivedMatchesScreen`, `AcceptTeamInvitationScreen` to `:shared-ui` commonMain
- Added `PlayedMatchCard` to commonMain (used by ArchivedMatchesScreen)
- Added `DateFormatter` expect/actual: Android uses `SimpleDateFormat`, iOS uses `NSDateFormatter`
- Added `UserAvatar` expect/actual: Android uses Coil `AsyncImage`, iOS shows placeholder icon
- Added `compose.materialIconsExtended` to commonMain — enables extended icons (Logout, CheckCircle, Error, Archive/Unarchive) on both platforms
- Replaced `collectAsStateWithLifecycle` (Android-only) with `collectAsState()` in AcceptTeamInvitationScreen
- Translated Spanish invitation strings to English in `strings.xml`

## Test plan
- [ ] Compile Android: `./gradlew :shared-ui:compileDebugKotlinAndroid`
- [ ] Compile iOS: `./gradlew :shared-ui:compileKotlinIosSimulatorArm64`
- [ ] Verify Settings screen shows user info and logout dialog
- [ ] Verify Archived Matches screen lists matches with archive/unarchive action
- [ ] Verify Accept Invitation screen handles loading/success/error states

Closes #273

🤖 Generated with [Claude Code](https://claude.com/claude-code)