### PR TITLE
[KMP-22] MainScreen (bottom nav) to :shared-ui

### DIFF
--- a/shared-ui/build.gradle.kts
+++ b/shared-ui/build.gradle.kts
@@ -16,6 +16,7 @@ kotlin {
             dependencies {
                 implementation(compose.runtime)
                 implementation(compose.foundation)
+                implementation(compose.animation)
                 implementation(compose.material3)
                 implementation(compose.materialIconsExtended)
                 implementation(compose.ui)

--- a/shared-ui/src/commonMain/kotlin/com/jesuslcorominas/teamflowmanager/ui/components/bottomnav/BottomNavItem.kt
+++ b/shared-ui/src/commonMain/kotlin/com/jesuslcorominas/teamflowmanager/ui/components/bottomnav/BottomNavItem.kt
@@ -1,0 +1,69 @@
+package com.jesuslcorominas.teamflowmanager.ui.components.bottomnav
+
+import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.animateDpAsState
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.spring
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.unit.dp
+import com.jesuslcorominas.teamflowmanager.ui.components.icon.FlipIcon
+
+@Composable
+fun BottomNavItem(iconVector: ImageVector, label: String, isSelected: Boolean) {
+    Box(
+        contentAlignment = Alignment.Center,
+    ) {
+        val animatedHeight by animateDpAsState(
+            targetValue = if (isSelected) 48.dp else 40.dp,
+            label = ""
+        )
+        val animatedAlpha by animateFloatAsState(
+            targetValue = if (isSelected) 1f else .5f,
+            label = ""
+        )
+        val animatedIconSize by animateDpAsState(
+            targetValue = if (isSelected) 24.dp else 20.dp,
+            animationSpec = spring(
+                stiffness = Spring.StiffnessLow,
+                dampingRatio = Spring.DampingRatioMediumBouncy
+            ), label = ""
+        )
+        Column(
+            modifier = Modifier
+                .height(animatedHeight),
+            verticalArrangement = Arrangement.Center,
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            FlipIcon(
+                modifier = Modifier
+                    .align(Alignment.CenterHorizontally)
+                    .alpha(animatedAlpha)
+                    .size(animatedIconSize),
+                isActive = isSelected,
+                activeIcon = iconVector,
+                inactiveIcon = iconVector,
+                contentDescription = label
+            )
+
+            if (isSelected) {
+                Text(
+                    text = label,
+                    maxLines = 1,
+                    style = MaterialTheme.typography.labelSmall
+                )
+            }
+        }
+    }
+}

--- a/shared-ui/src/commonMain/kotlin/com/jesuslcorominas/teamflowmanager/ui/components/icon/FlipIcon.kt
+++ b/shared-ui/src/commonMain/kotlin/com/jesuslcorominas/teamflowmanager/ui/components/icon/FlipIcon.kt
@@ -1,0 +1,43 @@
+package com.jesuslcorominas.teamflowmanager.ui.components.icon
+
+import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.spring
+import androidx.compose.foundation.layout.Box
+import androidx.compose.material3.Icon
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.graphics.vector.rememberVectorPainter
+
+@Composable
+fun FlipIcon(
+    modifier: Modifier = Modifier,
+    isActive: Boolean,
+    activeIcon: ImageVector,
+    inactiveIcon: ImageVector,
+    contentDescription: String,
+) {
+    val animationRotation by animateFloatAsState(
+        targetValue = if (isActive) 180f else 0f,
+        animationSpec = spring(
+            stiffness = Spring.StiffnessLow,
+            dampingRatio = Spring.DampingRatioMediumBouncy
+        ), label = ""
+    )
+    Box(
+        modifier = modifier
+            .graphicsLayer { rotationY = animationRotation },
+        contentAlignment = Alignment.Center,
+    ) {
+        Icon(
+            rememberVectorPainter(
+                image = if (animationRotation > 90f) activeIcon else inactiveIcon
+            ),
+            contentDescription = contentDescription,
+        )
+    }
+}

--- a/shared-ui/src/commonMain/kotlin/com/jesuslcorominas/teamflowmanager/ui/components/topbar/AppTopBar.kt
+++ b/shared-ui/src/commonMain/kotlin/com/jesuslcorominas/teamflowmanager/ui/components/topbar/AppTopBar.kt
@@ -1,0 +1,178 @@
+package com.jesuslcorominas.teamflowmanager.ui.components.topbar
+
+import androidx.compose.animation.Crossfade
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.Search
+import androidx.compose.material.icons.filled.Settings
+import androidx.compose.material3.CenterAlignedTopAppBar
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextField
+import androidx.compose.material3.TextFieldDefaults
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import com.jesuslcorominas.teamflowmanager.ui.main.LocalSearchState
+import com.jesuslcorominas.teamflowmanager.ui.navigation.Route
+import org.jetbrains.compose.resources.stringResource
+import teamflowmanager.shared_ui.generated.resources.Res
+import teamflowmanager.shared_ui.generated.resources.clear
+import teamflowmanager.shared_ui.generated.resources.close
+import teamflowmanager.shared_ui.generated.resources.close_search
+import teamflowmanager.shared_ui.generated.resources.search
+import teamflowmanager.shared_ui.generated.resources.settings
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun AppTopBar(
+    modifier: Modifier = Modifier,
+    uiConfig: Route.UiConfig?,
+    title: String?,
+    searchPlaceholder: String = "",
+    onBack: () -> Unit = {},
+    onSettings: () -> Unit = {},
+) {
+    val searchState = LocalSearchState.current
+
+    if (uiConfig?.showTopBar == true) {
+        Crossfade(
+            targetState = searchState.isActive,
+            animationSpec = tween(durationMillis = 300)
+        ) { isSearchActive ->
+            if (uiConfig.hasSearchBar && isSearchActive) {
+                SearchTopBar(modifier = modifier, placeholder = searchPlaceholder)
+            } else {
+                DefaultTopBar(
+                    modifier = modifier,
+                    uiConfig = uiConfig,
+                    title = title,
+                    onBack = onBack,
+                    onSettings = onSettings,
+                )
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun SearchTopBar(
+    modifier: Modifier = Modifier,
+    placeholder: String,
+) {
+    val searchState = LocalSearchState.current
+
+    TopAppBar(
+        modifier = modifier,
+        title = {
+            TextField(
+                value = searchState.query,
+                onValueChange = { searchState.query = it },
+                placeholder = { Text(placeholder) },
+                singleLine = true,
+                leadingIcon = {
+                    IconButton(
+                        onClick = {
+                            searchState.clear()
+                            searchState.isActive = false
+                        }
+                    ) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = stringResource(Res.string.close_search),
+                        )
+                    }
+                },
+                trailingIcon = {
+                    if (searchState.query.isNotEmpty()) {
+                        IconButton(onClick = { searchState.clear() }) {
+                            Icon(
+                                imageVector = Icons.Default.Close,
+                                contentDescription = stringResource(Res.string.clear)
+                            )
+                        }
+                    }
+                },
+                shape = RoundedCornerShape(48.dp),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(end = 16.dp)
+                    .background(Color.LightGray.copy(alpha = 0.3F), RoundedCornerShape(48.dp)),
+                colors = TextFieldDefaults.colors(
+                    focusedIndicatorColor = Color.Transparent,
+                    unfocusedIndicatorColor = Color.Transparent,
+                    disabledIndicatorColor = Color.Transparent,
+                    errorIndicatorColor = Color.Transparent,
+                    focusedContainerColor = Color.Transparent,
+                    unfocusedContainerColor = Color.Transparent,
+                    cursorColor = MaterialTheme.colorScheme.primary
+                )
+            )
+        }
+    )
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun DefaultTopBar(
+    modifier: Modifier = Modifier,
+    uiConfig: Route.UiConfig,
+    title: String?,
+    onBack: () -> Unit,
+    onSettings: () -> Unit,
+) {
+    val searchState = LocalSearchState.current
+
+    CenterAlignedTopAppBar(
+        modifier = modifier,
+        title = {
+            Text(
+                text = title ?: "",
+                maxLines = 1,
+                style = MaterialTheme.typography.titleLarge,
+                overflow = TextOverflow.Ellipsis,
+            )
+        },
+        navigationIcon = {
+            if (uiConfig.canGoBack) {
+                IconButton(onClick = onBack) {
+                    Icon(
+                        imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                        contentDescription = stringResource(Res.string.close),
+                    )
+                }
+            }
+        },
+        actions = {
+            if (uiConfig.hasSearchBar && !searchState.isActive) {
+                IconButton(onClick = { searchState.isActive = true }) {
+                    Icon(
+                        imageVector = Icons.Default.Search,
+                        contentDescription = stringResource(Res.string.search)
+                    )
+                }
+            }
+            if (uiConfig.showSettingsButton) {
+                IconButton(onClick = onSettings) {
+                    Icon(
+                        imageVector = Icons.Default.Settings,
+                        contentDescription = stringResource(Res.string.settings)
+                    )
+                }
+            }
+        },
+    )
+}

--- a/shared-ui/src/commonMain/kotlin/com/jesuslcorominas/teamflowmanager/ui/main/MainScreen.kt
+++ b/shared-ui/src/commonMain/kotlin/com/jesuslcorominas/teamflowmanager/ui/main/MainScreen.kt
@@ -1,0 +1,146 @@
+package com.jesuslcorominas.teamflowmanager.ui.main
+
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material3.FloatingActionButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Scaffold
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.jesuslcorominas.teamflowmanager.ui.components.topbar.AppTopBar
+import com.jesuslcorominas.teamflowmanager.ui.navigation.BottomNavigationBar
+import com.jesuslcorominas.teamflowmanager.ui.navigation.Route
+import com.jesuslcorominas.teamflowmanager.viewmodel.MainViewModel
+import org.jetbrains.compose.resources.stringResource
+import org.koin.compose.viewmodel.koinViewModel
+import teamflowmanager.shared_ui.generated.resources.Res
+import teamflowmanager.shared_ui.generated.resources.add_match_title
+import teamflowmanager.shared_ui.generated.resources.add_player_title
+import teamflowmanager.shared_ui.generated.resources.analysis_title
+import teamflowmanager.shared_ui.generated.resources.archived_matches
+import teamflowmanager.shared_ui.generated.resources.create_team_title
+import teamflowmanager.shared_ui.generated.resources.edit_team_title
+import teamflowmanager.shared_ui.generated.resources.matches_title
+import teamflowmanager.shared_ui.generated.resources.players_title
+import teamflowmanager.shared_ui.generated.resources.search_match_placeholder
+import teamflowmanager.shared_ui.generated.resources.settings_title
+import teamflowmanager.shared_ui.generated.resources.team_list_title
+import teamflowmanager.shared_ui.generated.resources.team_title
+
+/**
+ * Shared MainScreen shell: Scaffold with AppTopBar + BottomNavigationBar + FAB.
+ *
+ * Navigation is handled by the caller via callbacks. The content slot receives
+ * the scaffold [PaddingValues] so the caller can apply them to their NavHost or
+ * any other content composable.
+ *
+ * @param currentRoute the current destination route string (e.g. "matches")
+ * @param teamMode optional Team route mode (create/view/edit) for resolving UI config
+ * @param dynamicTitle optional title override (e.g. for match name set at runtime)
+ * @param onBackNavigate called when the back navigation icon is tapped
+ * @param onSettingsNavigate called when the settings icon is tapped
+ * @param onFabClick called when the FAB is tapped
+ * @param onBottomNavNavigate called with the destination string when a bottom nav tab is tapped
+ * @param content slot composable that receives the scaffold padding values
+ */
+@Composable
+fun MainScreen(
+    currentRoute: String?,
+    teamMode: String? = null,
+    dynamicTitle: String? = null,
+    viewModel: MainViewModel = koinViewModel(),
+    onBackNavigate: () -> Unit = {},
+    onSettingsNavigate: () -> Unit = {},
+    onFabClick: () -> Unit = {},
+    onBottomNavNavigate: (String) -> Unit = {},
+    content: @Composable (PaddingValues) -> Unit,
+) {
+    val isPresident by viewModel.isPresident.collectAsState()
+    val searchState = rememberSearchState()
+
+    val route = Route.fromValue(currentRoute)
+    val arguments: Map<String, Any?>? = teamMode?.let { mapOf(Route.Team.ARG_MODE to it) }
+    val uiConfig = route?.uiConfig(arguments)
+
+    val routeTitle = route?.toTitle(teamMode)
+    val title = dynamicTitle ?: routeTitle ?: ""
+
+    val searchPlaceholder = if (route is Route.Matches) {
+        stringResource(Res.string.search_match_placeholder)
+    } else {
+        ""
+    }
+
+    CompositionLocalProvider(LocalSearchState provides searchState) {
+        Scaffold(
+            topBar = {
+                AppTopBar(
+                    modifier = Modifier.padding(top = 16.dp),
+                    uiConfig = uiConfig,
+                    title = title,
+                    searchPlaceholder = searchPlaceholder,
+                    onBack = onBackNavigate,
+                    onSettings = onSettingsNavigate,
+                )
+            },
+            bottomBar = {
+                if (uiConfig?.showBottomBar == true) {
+                    BottomNavigationBar(
+                        currentRoute = currentRoute,
+                        isPresident = isPresident,
+                        onNavigate = onBottomNavNavigate,
+                    )
+                }
+            },
+            floatingActionButton = {
+                if (route != null && uiConfig?.showFab == true) {
+                    MainFloatingActionButton(route = route, onFabClick = onFabClick)
+                }
+            },
+        ) { paddingValues ->
+            content(paddingValues)
+        }
+    }
+}
+
+@Composable
+private fun MainFloatingActionButton(route: Route, onFabClick: () -> Unit) {
+    FloatingActionButton(onClick = onFabClick) {
+        Icon(
+            imageVector = if (route is Route.Team) Icons.Default.Edit else Icons.Default.Add,
+            contentDescription = route.toFabContentDescription()
+        )
+    }
+}
+
+@Composable
+private fun Route.toFabContentDescription(): String? = when (this) {
+    Route.Players -> stringResource(Res.string.add_player_title)
+    Route.Team -> stringResource(Res.string.edit_team_title)
+    Route.TeamList -> stringResource(Res.string.create_team_title)
+    Route.Matches -> stringResource(Res.string.add_match_title)
+    else -> null
+}
+
+@Composable
+internal fun Route.toTitle(teamMode: String? = null): String? = when (this) {
+    Route.Players -> stringResource(Res.string.players_title)
+    Route.Team -> when (teamMode) {
+        Route.Team.MODE_EDIT -> stringResource(Res.string.edit_team_title)
+        else -> stringResource(Res.string.team_title)
+    }
+    Route.TeamList -> stringResource(Res.string.team_list_title)
+    Route.Matches -> stringResource(Res.string.matches_title)
+    Route.ArchivedMatches -> stringResource(Res.string.archived_matches)
+    Route.Analysis -> stringResource(Res.string.analysis_title)
+    Route.Settings -> stringResource(Res.string.settings_title)
+    Route.Match -> null
+    else -> null
+}

--- a/shared-ui/src/commonMain/kotlin/com/jesuslcorominas/teamflowmanager/ui/main/SearchState.kt
+++ b/shared-ui/src/commonMain/kotlin/com/jesuslcorominas/teamflowmanager/ui/main/SearchState.kt
@@ -1,0 +1,26 @@
+package com.jesuslcorominas.teamflowmanager.ui.main
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.staticCompositionLocalOf
+
+class SearchState {
+    var query by mutableStateOf("")
+    var isActive by mutableStateOf(false)
+
+    fun clear() {
+        query = ""
+    }
+}
+
+@Composable
+fun rememberSearchState(): SearchState {
+    return remember { SearchState() }
+}
+
+val LocalSearchState = staticCompositionLocalOf<SearchState> {
+    error("No SearchState provided")
+}

--- a/shared-ui/src/commonMain/kotlin/com/jesuslcorominas/teamflowmanager/ui/navigation/BottomNavigationBar.kt
+++ b/shared-ui/src/commonMain/kotlin/com/jesuslcorominas/teamflowmanager/ui/navigation/BottomNavigationBar.kt
@@ -1,0 +1,119 @@
+package com.jesuslcorominas.teamflowmanager.ui.navigation
+
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.BarChart
+import androidx.compose.material.icons.filled.Group
+import androidx.compose.material.icons.filled.Groups
+import androidx.compose.material.icons.filled.People
+import androidx.compose.material.icons.filled.SportsSoccer
+import androidx.compose.material3.NavigationBar
+import androidx.compose.material3.NavigationBarItem
+import androidx.compose.material3.NavigationBarItemDefaults
+import androidx.compose.material3.Surface
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.unit.dp
+import com.jesuslcorominas.teamflowmanager.ui.components.bottomnav.BottomNavItem
+import com.jesuslcorominas.teamflowmanager.ui.theme.BackgroundContrast
+import com.jesuslcorominas.teamflowmanager.ui.theme.ContentContrast
+import com.jesuslcorominas.teamflowmanager.ui.theme.Primary
+import com.jesuslcorominas.teamflowmanager.ui.theme.PrimaryLight
+import org.jetbrains.compose.resources.stringResource
+import teamflowmanager.shared_ui.generated.resources.Res
+import teamflowmanager.shared_ui.generated.resources.nav_analysis
+import teamflowmanager.shared_ui.generated.resources.nav_matches
+import teamflowmanager.shared_ui.generated.resources.nav_players
+import teamflowmanager.shared_ui.generated.resources.nav_staff
+import teamflowmanager.shared_ui.generated.resources.nav_team
+import teamflowmanager.shared_ui.generated.resources.nav_teams
+
+@Composable
+fun BottomNavigationBar(
+    currentRoute: String?,
+    isPresident: Boolean = false,
+    onNavigate: (String) -> Unit,
+) {
+    val items: List<Route> = if (isPresident) {
+        listOf(Route.TeamList, Route.ClubMembers)
+    } else {
+        listOf(Route.Matches, Route.Players, Route.Analysis, Route.Team)
+    }
+
+    Surface(
+        shape = RoundedCornerShape(topStart = 24.dp, topEnd = 24.dp),
+        tonalElevation = 4.dp,
+        shadowElevation = 8.dp,
+        color = BackgroundContrast
+    ) {
+        NavigationBar(containerColor = Color.Transparent) {
+            items.forEach { route ->
+                val icon: ImageVector? = route.toIcon()
+                val label: String? = route.toLabel()
+
+                val selected = when {
+                    route is Route.Players && Route.fromValue(currentRoute) is Route.Players -> true
+                    route is Route.Team && Route.fromValue(currentRoute) is Route.Team -> true
+                    route is Route.TeamList && Route.fromValue(currentRoute) is Route.TeamList -> true
+                    route is Route.ClubMembers && Route.fromValue(currentRoute) is Route.ClubMembers -> true
+                    route is Route.Analysis && Route.fromValue(currentRoute) is Route.Analysis -> true
+                    route is Route.Matches && (Route.fromValue(currentRoute) is Route.Matches ||
+                        Route.fromValue(currentRoute) is Route.ArchivedMatches) -> true
+                    else -> false
+                }
+
+                NavigationBarItem(
+                    alwaysShowLabel = false,
+                    icon = {
+                        if (label != null && icon != null) {
+                            BottomNavItem(
+                                iconVector = icon,
+                                label = label,
+                                isSelected = selected
+                            )
+                        }
+                    },
+                    selected = selected,
+                    onClick = {
+                        if (!selected) {
+                            val destination = when (route) {
+                                is Route.Team -> route.createRoute(Route.Team.MODE_VIEW)
+                                else -> route.createRoute()
+                            }
+                            onNavigate(destination)
+                        }
+                    },
+                    colors = NavigationBarItemDefaults.colors(
+                        selectedIconColor = ContentContrast,
+                        unselectedIconColor = PrimaryLight,
+                        selectedTextColor = ContentContrast,
+                        unselectedTextColor = PrimaryLight,
+                        indicatorColor = Primary
+                    )
+                )
+            }
+        }
+    }
+}
+
+private fun Route.toIcon(): ImageVector? = when (this) {
+    Route.Players -> Icons.Default.Group
+    Route.Team -> Icons.Default.Groups
+    Route.TeamList -> Icons.Default.Groups
+    Route.ClubMembers -> Icons.Default.People
+    Route.Matches, Route.ArchivedMatches -> Icons.Default.SportsSoccer
+    Route.Analysis -> Icons.Default.BarChart
+    else -> null
+}
+
+@Composable
+private fun Route.toLabel(): String? = when (this) {
+    Route.Players -> stringResource(Res.string.nav_players)
+    Route.Team -> stringResource(Res.string.nav_team)
+    Route.TeamList -> stringResource(Res.string.nav_teams)
+    Route.ClubMembers -> stringResource(Res.string.nav_staff)
+    Route.Matches, Route.ArchivedMatches -> stringResource(Res.string.nav_matches)
+    Route.Analysis -> stringResource(Res.string.nav_analysis)
+    else -> null
+}

--- a/shared-ui/src/commonMain/kotlin/com/jesuslcorominas/teamflowmanager/ui/navigation/Route.kt
+++ b/shared-ui/src/commonMain/kotlin/com/jesuslcorominas/teamflowmanager/ui/navigation/Route.kt
@@ -1,0 +1,171 @@
+package com.jesuslcorominas.teamflowmanager.ui.navigation
+
+sealed class Route(
+    protected val path: String,
+    val showTopBar: Boolean = true,
+    val showBottomBar: Boolean = false,
+    val canGoBack: Boolean = false,
+    val showFab: Boolean = false,
+    val hasSearchBar: Boolean = false,
+    val showSettingsButton: Boolean = false
+) {
+
+    companion object {
+        val all by lazy {
+            listOf(
+                Splash,
+                Login,
+                Migration,
+                ClubSelection,
+                CreateClub,
+                JoinClub,
+                Players,
+                Team,
+                TeamList,
+                ClubMembers,
+                Matches,
+                ArchivedMatches,
+                CreateMatch,
+                PlayerWizard,
+                Match,
+                Analysis,
+                Settings,
+                AcceptTeamInvitation,
+            )
+        }
+
+        fun fromValue(value: String?): Route? {
+            if (value == null) return null
+
+            val base = value.substringBefore("?").substringBefore("/")
+
+            return all.firstOrNull { it.path == base }
+        }
+    }
+
+    fun createRoute(vararg params: Any?): String =
+        path + if (params.isNotEmpty()) params.joinToString("") { "/$it" } else ""
+
+    data class UiConfig(
+        val showTopBar: Boolean,
+        val showBottomBar: Boolean,
+        val canGoBack: Boolean,
+        val showFab: Boolean,
+        val hasSearchBar: Boolean,
+        val showSettingsButton: Boolean,
+    )
+
+    open fun uiConfig(arguments: Map<String, Any?>?): UiConfig =
+        UiConfig(
+            showTopBar = showTopBar,
+            showBottomBar = showBottomBar,
+            canGoBack = canGoBack,
+            showFab = showFab,
+            hasSearchBar = hasSearchBar,
+            showSettingsButton = showSettingsButton,
+        )
+
+    data object Matches : Route(
+        path = "matches",
+        showBottomBar = true,
+        showFab = true,
+        hasSearchBar = true,
+        showSettingsButton = true
+    )
+
+    data object Match : Route(path = "match", canGoBack = true) {
+        const val ARG_MATCH_ID = "matchId"
+        private const val PATH = "match"
+
+        const val FULL_ROUTE = "$PATH/{$ARG_MATCH_ID}"
+    }
+
+    data object Settings : Route(path = "settings", canGoBack = true)
+
+    data object Splash : Route(path = "splash", showTopBar = false)
+
+    data object Login : Route(path = "login", showTopBar = false)
+
+    data object Migration : Route(path = "migration", showTopBar = false)
+
+    data object ClubSelection : Route(path = "club_selection", showTopBar = false)
+
+    data object CreateClub : Route(path = "create_club", showTopBar = false)
+
+    data object JoinClub : Route(path = "join_club", showTopBar = false)
+
+    data object Team : Route(
+        path = "team",
+        showBottomBar = true
+    ) {
+        private const val PATH = "team"
+        const val ARG_MODE = "mode"
+        const val MODE_CREATE = "create"
+        const val MODE_VIEW = "view"
+        const val MODE_EDIT = "edit"
+
+        const val FULL_ROUTE = "$PATH/{$ARG_MODE}"
+
+        override fun uiConfig(arguments: Map<String, Any?>?): UiConfig {
+            val mode = arguments?.get(ARG_MODE) as? String ?: MODE_VIEW
+            return UiConfig(
+                showTopBar = mode == MODE_EDIT || mode == MODE_VIEW,
+                showBottomBar = mode == MODE_EDIT || mode == MODE_VIEW,
+                canGoBack = mode == MODE_EDIT,
+                showFab = mode == MODE_VIEW,
+                hasSearchBar = false,
+                showSettingsButton = mode == MODE_EDIT || mode == MODE_VIEW,
+            )
+        }
+    }
+
+    data object TeamList : Route(
+        path = "team_list",
+        showTopBar = true,
+        showBottomBar = true,
+        showFab = true,
+        hasSearchBar = false,
+        showSettingsButton = true
+    )
+
+    data object ClubMembers : Route(
+        path = "club_members",
+        showTopBar = true,
+        showBottomBar = true,
+        showSettingsButton = true
+    )
+
+    data object Players : Route(path = "players", showBottomBar = true, showSettingsButton = true)
+
+    data object PlayerWizard : Route(path = "player_wizard", showTopBar = false) {
+        const val ARG_PLAYER_ID = "playerId"
+        private const val PATH = "player_wizard"
+        const val FULL_ROUTE = "$PATH/{$ARG_PLAYER_ID}"
+    }
+
+    data object ArchivedMatches : Route(
+        path = "archived_matches",
+        showBottomBar = true,
+        canGoBack = true,
+        showSettingsButton = true
+    )
+
+    data object CreateMatch : Route(path = "create_match", showTopBar = false) {
+        const val DEFAULT_MATCH_ID = 0L
+        const val ARG_MATCH_ID = "matchId"
+        private const val PATH = "create_match"
+
+        const val FULL_ROUTE = "$PATH/{$ARG_MATCH_ID}"
+    }
+
+    data object Analysis : Route(path = "analysis", showBottomBar = true, showSettingsButton = true)
+
+    data object AcceptTeamInvitation : Route(path = "accept_team_invitation", showTopBar = false) {
+        const val ARG_TEAM_ID = "teamId"
+        private const val PATH = "accept_team_invitation"
+
+        const val FULL_ROUTE = "$PATH?$ARG_TEAM_ID={$ARG_TEAM_ID}"
+
+        fun createRoute(teamId: String): String = "$PATH?$ARG_TEAM_ID=$teamId"
+    }
+}


### PR DESCRIPTION
## Summary
- Migrates `Route` sealed class (pure Kotlin) to `shared-ui/commonMain`
- Migrates `SearchState` + `LocalSearchState` (pure Compose) to `shared-ui/commonMain`
- Migrates `FlipIcon`, `BottomNavItem`, `BottomNavigationBar`, `AppTopBar` as CMP versions using callbacks instead of `NavController`
- Creates `MainScreen` scaffold shell in `shared-ui/commonMain` — accepts `content: @Composable (PaddingValues) -> Unit` slot so both Android (NavHost) and iOS (state-based nav) can plug in their navigation
- Adds `compose.animation` to `shared-ui` commonMain dependencies

## Key adaptations for CMP
- `BottomNavItem`: `labelResId: Int` → `label: String` (no Android R.string)
- `BottomNavigationBar`: `NavController` → `currentRoute: String?` + `onNavigate: (String) -> Unit`
- `AppTopBar`: `NavController` + `BackHandlerController` → `onBack: () -> Unit` + `onSettings: () -> Unit`
- `MainScreen`: wraps the Scaffold shell; navigation wiring stays platform-specific (KMP-25)

## Test plan
- [x] `./gradlew :shared-ui:compileKotlinIosSimulatorArm64` — BUILD SUCCESSFUL
- [x] `./gradlew :shared-ui:compileDebugKotlin` — BUILD SUCCESSFUL
- [ ] Full iOS nav wiring deferred to KMP-25

🤖 Generated with [Claude Code](https://claude.com/claude-code)