### PR TITLE
Fix iOS functional bugs (players, match detail, logout, write ops)

### DIFF
--- a/data/remote/src/iosMain/kotlin/com/jesuslcorominas/teamflowmanager/data/remote/datasource/IosDataSourceStubs.kt
+++ b/data/remote/src/iosMain/kotlin/com/jesuslcorominas/teamflowmanager/data/remote/datasource/IosDataSourceStubs.kt
@@ -5,14 +5,12 @@ import com.jesuslcorominas.teamflowmanager.data.core.datasource.DynamicLinkDataS
 import com.jesuslcorominas.teamflowmanager.data.core.datasource.GoalDataSource
 import com.jesuslcorominas.teamflowmanager.data.core.datasource.ImageStorageDataSource
 import com.jesuslcorominas.teamflowmanager.data.core.datasource.MatchOperationDataSource
-import com.jesuslcorominas.teamflowmanager.data.core.datasource.PlayerDataSource
 import com.jesuslcorominas.teamflowmanager.data.core.datasource.PlayerSubstitutionDataSource
 import com.jesuslcorominas.teamflowmanager.data.core.datasource.PlayerTimeDataSource
 import com.jesuslcorominas.teamflowmanager.data.core.datasource.PlayerTimeHistoryDataSource
 import com.jesuslcorominas.teamflowmanager.domain.model.Club
 import com.jesuslcorominas.teamflowmanager.domain.model.Goal
 import com.jesuslcorominas.teamflowmanager.domain.model.MatchOperation
-import com.jesuslcorominas.teamflowmanager.domain.model.Player
 import com.jesuslcorominas.teamflowmanager.domain.model.PlayerSubstitution
 import com.jesuslcorominas.teamflowmanager.domain.model.PlayerTime
 import com.jesuslcorominas.teamflowmanager.domain.model.PlayerTimeHistory
@@ -33,23 +31,6 @@ class ClubFirestoreDataSourceImpl : ClubDataSource {
     override suspend fun getClubByInvitationCode(invitationCode: String): Club? = null
 }
 
-class PlayerFirestoreDataSourceImpl : PlayerDataSource {
-    override fun getAllPlayers(): Flow<List<Player>> = flowOf(emptyList())
-    override suspend fun getPlayerById(playerId: Long): Player? = null
-    override suspend fun getCaptainPlayer(): Player? = null
-    override suspend fun setPlayerAsCaptain(playerId: Long) =
-        throw NotImplementedError("setPlayerAsCaptain not implemented for iOS Phase 2")
-    override suspend fun removePlayerAsCaptain(playerId: Long) =
-        throw NotImplementedError("removePlayerAsCaptain not implemented for iOS Phase 2")
-    override suspend fun updatePlayer(player: Player) =
-        throw NotImplementedError("updatePlayer not implemented for iOS Phase 2")
-    override suspend fun insertPlayer(player: Player): Long =
-        throw NotImplementedError("insertPlayer not implemented for iOS Phase 2")
-    override suspend fun deletePlayer(playerId: Long) =
-        throw NotImplementedError("deletePlayer not implemented for iOS Phase 2")
-    override suspend fun getAllPlayersDirect(): List<Player> = emptyList()
-    override suspend fun clearLocalData() = Unit
-}
 
 class GoalFirestoreDataSourceImpl : GoalDataSource {
     override fun getMatchGoals(matchId: Long): Flow<List<Goal>> = flowOf(emptyList())

--- a/data/remote/src/iosMain/kotlin/com/jesuslcorominas/teamflowmanager/data/remote/datasource/MatchFirestoreDataSourceImpl.kt
+++ b/data/remote/src/iosMain/kotlin/com/jesuslcorominas/teamflowmanager/data/remote/datasource/MatchFirestoreDataSourceImpl.kt
@@ -3,12 +3,15 @@ package com.jesuslcorominas.teamflowmanager.data.remote.datasource
 import com.jesuslcorominas.teamflowmanager.data.core.datasource.MatchDataSource
 import com.jesuslcorominas.teamflowmanager.data.remote.firestore.MatchFirestoreModel
 import com.jesuslcorominas.teamflowmanager.data.remote.firestore.toDomain
+import com.jesuslcorominas.teamflowmanager.data.remote.firestore.toFirestoreModel
 import com.jesuslcorominas.teamflowmanager.data.remote.util.toStableId
 import com.jesuslcorominas.teamflowmanager.domain.model.Match
 import dev.gitlive.firebase.auth.FirebaseAuth
 import dev.gitlive.firebase.firestore.FirebaseFirestore
+import dev.gitlive.firebase.firestore.FirebaseFirestoreException
 import dev.gitlive.firebase.firestore.where
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.emitAll
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.map
@@ -42,6 +45,25 @@ class MatchFirestoreDataSourceImpl(
     private fun documentToMatch(docId: String, model: MatchFirestoreModel, teamDocId: String): Match =
         model.copy(id = docId, teamId = teamDocId).toDomain()
 
+    /**
+     * Finds the Firestore document ID for a given domain match ID (Long).
+     * Fetches all team matches and returns the document whose stable ID matches.
+     */
+    private suspend fun findDocumentIdByMatchId(teamDocId: String, matchId: Long): String? {
+        return try {
+            val snapshot = firestore.collection(MATCHES_COLLECTION)
+                .where { "teamId" equalTo teamDocId }
+                .get()
+            snapshot.documents.firstOrNull { doc ->
+                doc.id.toStableId() == matchId
+            }?.id
+        } catch (e: CancellationException) {
+            throw e
+        } catch (_: Exception) {
+            null
+        }
+    }
+
     override fun getAllMatches(): Flow<List<Match>> = flow {
         val currentUserId = firebaseAuth.currentUser?.uid
         if (currentUserId == null) {
@@ -67,7 +89,9 @@ class MatchFirestoreDataSourceImpl(
                         null
                     }
                 }
-            }
+            }.catch { e ->
+                if (e is FirebaseFirestoreException) emit(emptyList()) else throw e
+            },
         )
     }
 
@@ -96,7 +120,9 @@ class MatchFirestoreDataSourceImpl(
                         null
                     }
                 }
-            }
+            }.catch { e ->
+                if (e is FirebaseFirestoreException) emit(emptyList()) else throw e
+            },
         )
     }
 
@@ -124,7 +150,9 @@ class MatchFirestoreDataSourceImpl(
                         null
                     }
                 }.find { it.id == matchId }
-            }
+            }.catch { e ->
+                if (e is FirebaseFirestoreException) emit(null) else throw e
+            },
         )
     }
 
@@ -151,19 +179,61 @@ class MatchFirestoreDataSourceImpl(
         }
     }
 
-    // Write operations not implemented for iOS Phase 2 MVP
+    override suspend fun insertMatch(match: Match): Long {
+        val teamDocId = getTeamDocumentId()
+            ?: throw IllegalStateException("No team found for current user")
+        val model = match.toFirestoreModel().copy(teamId = teamDocId)
+        return try {
+            val docRef = firestore.collection(MATCHES_COLLECTION).add(model)
+            docRef.id.toStableId()
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            throw e
+        }
+    }
 
-    override suspend fun insertMatch(match: Match): Long =
-        throw NotImplementedError("insertMatch not implemented for iOS Phase 2")
+    override suspend fun updateMatch(match: Match) {
+        val teamDocId = getTeamDocumentId()
+            ?: throw IllegalStateException("No team found for current user")
+        val documentId = findDocumentIdByMatchId(teamDocId, match.id)
+            ?: throw IllegalStateException("Cannot find Firestore document for match ${match.id}")
+        val model = match.toFirestoreModel().copy(id = documentId, teamId = teamDocId)
+        try {
+            firestore.collection(MATCHES_COLLECTION).document(documentId).set(model)
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            throw e
+        }
+    }
 
-    override suspend fun updateMatch(match: Match) =
-        throw NotImplementedError("updateMatch not implemented for iOS Phase 2")
+    override suspend fun deleteMatch(matchId: Long) {
+        val teamDocId = getTeamDocumentId()
+            ?: throw IllegalStateException("No team found for current user")
+        val documentId = findDocumentIdByMatchId(teamDocId, matchId)
+            ?: throw IllegalStateException("Cannot find Firestore document for match $matchId")
+        try {
+            firestore.collection(MATCHES_COLLECTION).document(documentId).delete()
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            throw e
+        }
+    }
 
-    override suspend fun deleteMatch(matchId: Long) =
-        throw NotImplementedError("deleteMatch not implemented for iOS Phase 2")
-
-    override suspend fun updateMatchCaptain(matchId: Long, captainId: Long?) =
-        throw NotImplementedError("updateMatchCaptain not implemented for iOS Phase 2")
+    override suspend fun updateMatchCaptain(matchId: Long, captainId: Long?) {
+        val teamDocId = getTeamDocumentId() ?: return
+        val documentId = findDocumentIdByMatchId(teamDocId, matchId) ?: return
+        try {
+            firestore.collection(MATCHES_COLLECTION).document(documentId)
+                .update("captainId" to (captainId ?: 0L))
+        } catch (e: CancellationException) {
+            throw e
+        } catch (_: Exception) {
+            // Best-effort — not critical if this fails silently
+        }
+    }
 
     override suspend fun getAllMatchesDirect(): List<Match> = emptyList()
 

--- a/data/remote/src/iosMain/kotlin/com/jesuslcorominas/teamflowmanager/data/remote/datasource/PlayerFirestoreDataSourceImpl.kt
+++ b/data/remote/src/iosMain/kotlin/com/jesuslcorominas/teamflowmanager/data/remote/datasource/PlayerFirestoreDataSourceImpl.kt
@@ -1,0 +1,245 @@
+package com.jesuslcorominas.teamflowmanager.data.remote.datasource
+
+import com.jesuslcorominas.teamflowmanager.data.core.datasource.PlayerDataSource
+import com.jesuslcorominas.teamflowmanager.data.remote.firestore.PlayerFirestoreModel
+import com.jesuslcorominas.teamflowmanager.data.remote.firestore.toDomain
+import com.jesuslcorominas.teamflowmanager.data.remote.firestore.toFirestoreModel
+import com.jesuslcorominas.teamflowmanager.data.remote.util.toStableId
+import com.jesuslcorominas.teamflowmanager.domain.model.Player
+import dev.gitlive.firebase.auth.FirebaseAuth
+import dev.gitlive.firebase.firestore.FirebaseFirestore
+import dev.gitlive.firebase.firestore.FirebaseFirestoreException
+import dev.gitlive.firebase.firestore.where
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.emitAll
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.map
+import kotlin.coroutines.cancellation.CancellationException
+
+class PlayerFirestoreDataSourceImpl(
+    private val firestore: FirebaseFirestore,
+    private val firebaseAuth: FirebaseAuth,
+) : PlayerDataSource {
+
+    companion object {
+        private const val PLAYERS_COLLECTION = "players"
+        private const val TEAMS_COLLECTION = "teams"
+    }
+
+    private suspend fun getTeamDocumentId(): String? {
+        val currentUserId = firebaseAuth.currentUser?.uid ?: return null
+        return try {
+            val snapshot = firestore.collection(TEAMS_COLLECTION)
+                .where { "ownerId" equalTo currentUserId }
+                .limit(1)
+                .get()
+            snapshot.documents.firstOrNull()?.id
+        } catch (e: CancellationException) {
+            throw e
+        } catch (_: Exception) {
+            null
+        }
+    }
+
+    private suspend fun findDocumentIdByPlayerId(teamDocId: String, playerId: Long): String? {
+        return try {
+            val snapshot = firestore.collection(PLAYERS_COLLECTION)
+                .where { "teamId" equalTo teamDocId }
+                .get()
+            snapshot.documents.firstOrNull { doc ->
+                doc.id.toStableId() == playerId
+            }?.id
+        } catch (e: CancellationException) {
+            throw e
+        } catch (_: Exception) {
+            null
+        }
+    }
+
+    override fun getAllPlayers(): Flow<List<Player>> = flow {
+        val currentUserId = firebaseAuth.currentUser?.uid
+        if (currentUserId == null) {
+            emit(emptyList())
+            return@flow
+        }
+        val teamDocId = getTeamDocumentId()
+        if (teamDocId == null) {
+            emit(emptyList())
+            return@flow
+        }
+        val snapshots = firestore.collection(PLAYERS_COLLECTION)
+            .where { "teamId" equalTo teamDocId }
+            .where { "deleted" equalTo false }
+            .snapshots
+        emitAll(
+            snapshots.map { qs ->
+                qs.documents.mapNotNull { doc ->
+                    try {
+                        val model = doc.data<PlayerFirestoreModel>()
+                        model.copy(id = doc.id, teamId = teamDocId).toDomain()
+                    } catch (_: Exception) {
+                        null
+                    }
+                }
+            }.catch { e ->
+                if (e is FirebaseFirestoreException) emit(emptyList()) else throw e
+            },
+        )
+    }
+
+    override suspend fun getPlayerById(playerId: Long): Player? {
+        val teamDocId = getTeamDocumentId() ?: return null
+        return try {
+            val snapshot = firestore.collection(PLAYERS_COLLECTION)
+                .where { "teamId" equalTo teamDocId }
+                .where { "deleted" equalTo false }
+                .get()
+            snapshot.documents.mapNotNull { doc ->
+                try {
+                    val model = doc.data<PlayerFirestoreModel>()
+                    model.copy(id = doc.id, teamId = teamDocId).toDomain()
+                } catch (_: Exception) {
+                    null
+                }
+            }.find { it.id == playerId }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (_: Exception) {
+            null
+        }
+    }
+
+    override suspend fun getCaptainPlayer(): Player? {
+        val teamDocId = getTeamDocumentId() ?: return null
+        return try {
+            val snapshot = firestore.collection(PLAYERS_COLLECTION)
+                .where { "teamId" equalTo teamDocId }
+                .where { "captain" equalTo true }
+                .where { "deleted" equalTo false }
+                .get()
+            snapshot.documents.firstOrNull()?.let { doc ->
+                try {
+                    val model = doc.data<PlayerFirestoreModel>()
+                    model.copy(id = doc.id, teamId = teamDocId).toDomain()
+                } catch (_: Exception) {
+                    null
+                }
+            }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (_: Exception) {
+            null
+        }
+    }
+
+    override suspend fun setPlayerAsCaptain(playerId: Long) {
+        val teamDocId = getTeamDocumentId() ?: return
+        // Clear existing captains first
+        try {
+            val snapshot = firestore.collection(PLAYERS_COLLECTION)
+                .where { "teamId" equalTo teamDocId }
+                .where { "captain" equalTo true }
+                .get()
+            snapshot.documents.forEach { doc ->
+                firestore.collection(PLAYERS_COLLECTION).document(doc.id)
+                    .update("captain" to false)
+            }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (_: Exception) {
+            // Best-effort clear
+        }
+        // Set new captain
+        val documentId = findDocumentIdByPlayerId(teamDocId, playerId) ?: return
+        try {
+            firestore.collection(PLAYERS_COLLECTION).document(documentId)
+                .update("captain" to true)
+        } catch (e: CancellationException) {
+            throw e
+        } catch (_: Exception) {
+            // Best-effort
+        }
+    }
+
+    override suspend fun removePlayerAsCaptain(playerId: Long) {
+        val teamDocId = getTeamDocumentId() ?: return
+        val documentId = findDocumentIdByPlayerId(teamDocId, playerId) ?: return
+        try {
+            firestore.collection(PLAYERS_COLLECTION).document(documentId)
+                .update("captain" to false)
+        } catch (e: CancellationException) {
+            throw e
+        } catch (_: Exception) {
+            // Best-effort
+        }
+    }
+
+    override suspend fun insertPlayer(player: Player): Long {
+        val teamDocId = getTeamDocumentId()
+            ?: throw IllegalStateException("No team found for current user")
+        val model = player.toFirestoreModel().copy(teamId = teamDocId)
+        return try {
+            val docRef = firestore.collection(PLAYERS_COLLECTION).add(model)
+            docRef.id.toStableId()
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            throw e
+        }
+    }
+
+    override suspend fun updatePlayer(player: Player) {
+        val teamDocId = getTeamDocumentId()
+            ?: throw IllegalStateException("No team found for current user")
+        val documentId = findDocumentIdByPlayerId(teamDocId, player.id)
+            ?: throw IllegalStateException("Cannot find Firestore document for player ${player.id}")
+        val model = player.toFirestoreModel().copy(id = documentId, teamId = teamDocId)
+        try {
+            firestore.collection(PLAYERS_COLLECTION).document(documentId).set(model)
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            throw e
+        }
+    }
+
+    override suspend fun deletePlayer(playerId: Long) {
+        val teamDocId = getTeamDocumentId() ?: return
+        val documentId = findDocumentIdByPlayerId(teamDocId, playerId) ?: return
+        try {
+            firestore.collection(PLAYERS_COLLECTION).document(documentId)
+                .update("deleted" to true)
+        } catch (e: CancellationException) {
+            throw e
+        } catch (_: Exception) {
+            // Best-effort
+        }
+    }
+
+    override suspend fun getAllPlayersDirect(): List<Player> {
+        val teamDocId = getTeamDocumentId() ?: return emptyList()
+        return try {
+            val snapshot = firestore.collection(PLAYERS_COLLECTION)
+                .where { "teamId" equalTo teamDocId }
+                .where { "deleted" equalTo false }
+                .get()
+            snapshot.documents.mapNotNull { doc ->
+                try {
+                    val model = doc.data<PlayerFirestoreModel>()
+                    model.copy(id = doc.id, teamId = teamDocId).toDomain()
+                } catch (_: Exception) {
+                    null
+                }
+            }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (_: Exception) {
+            emptyList()
+        }
+    }
+
+    override suspend fun clearLocalData() {
+        // No-op for remote data source
+    }
+}

--- a/data/remote/src/iosMain/kotlin/com/jesuslcorominas/teamflowmanager/data/remote/datasource/TeamFirestoreDataSourceImpl.kt
+++ b/data/remote/src/iosMain/kotlin/com/jesuslcorominas/teamflowmanager/data/remote/datasource/TeamFirestoreDataSourceImpl.kt
@@ -6,8 +6,10 @@ import com.jesuslcorominas.teamflowmanager.data.remote.firestore.toDomain
 import com.jesuslcorominas.teamflowmanager.domain.model.Team
 import dev.gitlive.firebase.auth.FirebaseAuth
 import dev.gitlive.firebase.firestore.FirebaseFirestore
+import dev.gitlive.firebase.firestore.FirebaseFirestoreException
 import dev.gitlive.firebase.firestore.where
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.emitAll
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.map
@@ -43,6 +45,8 @@ class TeamFirestoreDataSourceImpl(
                         null
                     }
                 }
+            }.catch { e ->
+                if (e is FirebaseFirestoreException) emit(null) else throw e
             }
         )
     }
@@ -61,6 +65,8 @@ class TeamFirestoreDataSourceImpl(
                         null
                     }
                 }
+            }.catch { e ->
+                if (e is FirebaseFirestoreException) emit(null) else throw e
             }
         )
     }
@@ -78,6 +84,8 @@ class TeamFirestoreDataSourceImpl(
                         null
                     }
                 }
+            }.catch { e ->
+                if (e is FirebaseFirestoreException) emit(emptyList()) else throw e
             }
         )
     }

--- a/data/remote/src/iosMain/kotlin/com/jesuslcorominas/teamflowmanager/data/remote/di/DataRemoteModule.kt
+++ b/data/remote/src/iosMain/kotlin/com/jesuslcorominas/teamflowmanager/data/remote/di/DataRemoteModule.kt
@@ -52,9 +52,11 @@ actual val dataRemoteModule: Module = module {
     singleOf(::MatchFirestoreDataSourceImpl) bind MatchDataSource::class
     singleOf(::ClubMemberFirestoreDataSourceImpl) bind ClubMemberDataSource::class
 
+    // Real player datasource
+    single<PlayerDataSource> { PlayerFirestoreDataSourceImpl(get(), get()) }
+
     // Phase 2 stubs — read operations return empty/null, writes throw NotImplementedError
     single<ClubDataSource> { ClubFirestoreDataSourceImpl() }
-    single<PlayerDataSource> { PlayerFirestoreDataSourceImpl() }
     single<GoalDataSource> { GoalFirestoreDataSourceImpl() }
     single<PlayerSubstitutionDataSource> { PlayerSubstitutionFirestoreDataSourceImpl() }
     single<PlayerTimeDataSource> { PlayerTimeFirestoreDataSourceImpl() }

--- a/data/remote/src/iosMain/kotlin/com/jesuslcorominas/teamflowmanager/data/remote/firestore/MatchFirestoreModel.kt
+++ b/data/remote/src/iosMain/kotlin/com/jesuslcorominas/teamflowmanager/data/remote/firestore/MatchFirestoreModel.kt
@@ -86,3 +86,33 @@ fun MatchPeriodFirestoreModel.toDomain(): MatchPeriod =
         startTimeMillis = startTimeMillis,
         endTimeMillis = endTimeMillis,
     )
+
+fun Match.toFirestoreModel(): MatchFirestoreModel =
+    MatchFirestoreModel(
+        id = "",       // set by data source from document ID
+        teamId = "",   // set by data source
+        teamName = teamName,
+        opponent = opponent,
+        location = location,
+        dateTime = dateTime,
+        numberOfPeriods = periodType.numberOfPeriods,
+        squadCallUpIds = squadCallUpIds,
+        captainId = captainId,
+        startingLineupIds = startingLineupIds,
+        status = status.name,
+        archived = archived,
+        pauseCount = pauseCount,
+        goals = goals,
+        opponentGoals = opponentGoals,
+        timeoutStartTimeMillis = timeoutStartTimeMillis,
+        periods = periods.map { it.toFirestoreModel() },
+        lastCompletedOperationId = lastCompletedOperationId,
+    )
+
+fun MatchPeriod.toFirestoreModel(): MatchPeriodFirestoreModel =
+    MatchPeriodFirestoreModel(
+        periodNumber = periodNumber,
+        periodDuration = periodDuration,
+        startTimeMillis = startTimeMillis,
+        endTimeMillis = endTimeMillis,
+    )

--- a/data/remote/src/iosMain/kotlin/com/jesuslcorominas/teamflowmanager/data/remote/firestore/PlayerFirestoreModel.kt
+++ b/data/remote/src/iosMain/kotlin/com/jesuslcorominas/teamflowmanager/data/remote/firestore/PlayerFirestoreModel.kt
@@ -1,0 +1,53 @@
+package com.jesuslcorominas.teamflowmanager.data.remote.firestore
+
+import com.jesuslcorominas.teamflowmanager.data.remote.util.toStableId
+import com.jesuslcorominas.teamflowmanager.domain.model.Player
+import com.jesuslcorominas.teamflowmanager.domain.model.Position
+import kotlinx.serialization.Serializable
+
+/**
+ * iOS Firestore model for Player — uses @Serializable (kotlinx.serialization).
+ * Note: the field name is "captain" in Firestore (matches Android's @PropertyName("captain")).
+ * The document ID is injected externally from DocumentSnapshot.id.
+ */
+@Serializable
+data class PlayerFirestoreModel(
+    val id: String = "",
+    val firstName: String = "",
+    val lastName: String = "",
+    val number: Int = 0,
+    val positions: String = "",
+    val teamId: String = "",
+    val captain: Boolean = false,
+    val imageUri: String? = null,
+    val deleted: Boolean = false,
+)
+
+fun PlayerFirestoreModel.toDomain(): Player =
+    Player(
+        id = id.toStableId(),
+        firstName = firstName,
+        lastName = lastName,
+        number = number,
+        positions = positions
+            .split(",")
+            .filter { it.isNotBlank() }
+            .mapNotNull { Position.fromId(it.trim()) },
+        teamId = teamId.toStableId(),
+        isCaptain = captain,
+        imageUri = imageUri,
+        deleted = deleted,
+    )
+
+fun Player.toFirestoreModel(): PlayerFirestoreModel =
+    PlayerFirestoreModel(
+        id = "",
+        firstName = firstName,
+        lastName = lastName,
+        number = number,
+        positions = positions.joinToString(",") { it.id },
+        teamId = "",
+        captain = isCaptain,
+        imageUri = imageUri,
+        deleted = deleted,
+    )

--- a/di/src/iosMain/kotlin/com/jesuslcorominas/teamflowmanager/di/IosModule.kt
+++ b/di/src/iosMain/kotlin/com/jesuslcorominas/teamflowmanager/di/IosModule.kt
@@ -2,6 +2,8 @@ package com.jesuslcorominas.teamflowmanager.di
 
 import com.jesuslcorominas.teamflowmanager.domain.analytics.AnalyticsTracker
 import com.jesuslcorominas.teamflowmanager.domain.analytics.CrashReporter
+import com.jesuslcorominas.teamflowmanager.domain.model.MatchReportData
+import com.jesuslcorominas.teamflowmanager.domain.utils.MatchReportPdfExporter
 import com.jesuslcorominas.teamflowmanager.domain.utils.TimeProvider
 import com.jesuslcorominas.teamflowmanager.viewmodel.AcceptTeamInvitationViewModel
 import com.jesuslcorominas.teamflowmanager.viewmodel.AnalysisViewModel
@@ -38,6 +40,7 @@ val iosModule = module {
     single<AnalyticsTracker> { NoOpAnalyticsTracker() }
     single<CrashReporter> { NoOpCrashReporter() }
     single<TimeProvider> { IosTimeProvider() }
+    single<MatchReportPdfExporter> { NoOpMatchReportPdfExporter() }
     factory { createTimeTicker(get()) } bind TimeTicker::class
 
     // ── ViewModels (no-param) ────────────────────────────────────────────────
@@ -259,4 +262,8 @@ private class NoOpCrashReporter : CrashReporter {
     override fun setCustomKey(key: String, value: String) = Unit
     override fun setCustomKey(key: String, value: Int) = Unit
     override fun setCustomKey(key: String, value: Boolean) = Unit
+}
+
+private class NoOpMatchReportPdfExporter : MatchReportPdfExporter {
+    override fun exportMatchReportToPdf(matchReportData: MatchReportData): String? = null
 }


### PR DESCRIPTION
## Summary

- **Real `PlayerFirestoreDataSourceImpl`**: Was returning `flowOf(emptyList())` — now queries Firestore with proper team filtering. Players screen now shows data.
- **`MatchFirestoreDataSourceImpl` write operations**: `updateMatch`, `insertMatch`, `deleteMatch`, `updateMatchCaptain` were throwing `NotImplementedError` — all implemented with `findDocumentIdByMatchId` helper. Fixes archive crash.
- **`NoOpMatchReportPdfExporter` in `IosModule`**: `MatchViewModel` required `MatchReportPdfExporter` via Koin but it wasn't registered on iOS — caused crash when navigating to match detail.
- **Permission error handling on Firestore snapshot flows**: `FirebaseFirestoreException` is now caught in `MatchFirestoreDataSourceImpl` and `TeamFirestoreDataSourceImpl` flows instead of propagating as an unhandled crash. Fixes logout crash.
- **`PlayerFirestoreModel`** (`@Serializable`): New iOS Firestore model, mirrors Android's `@DocumentId`/`@PropertyName` model structure.

## Test plan

- [ ] Players screen shows team players
- [ ] Archiving a match completes without crash
- [ ] Navigating to match detail opens `MatchScreen` without crash
- [ ] Signing out does not crash the app
- [ ] Updating player data persists to Firestore

🤖 Generated with [Claude Code](https://claude.com/claude-code)