### PR TITLE
Fix #284: PlayerWizard always opens on name/number page (iOS ViewModel caching)

### DIFF
--- a/shared-ui/src/commonMain/kotlin/com/jesuslcorominas/teamflowmanager/ui/players/wizard/PlayerWizardScreen.kt
+++ b/shared-ui/src/commonMain/kotlin/com/jesuslcorominas/teamflowmanager/ui/players/wizard/PlayerWizardScreen.kt
@@ -41,6 +41,13 @@ fun PlayerWizardScreen(
     val captainConfirmationState by wizardViewModel.captainConfirmationState.collectAsState()
     val showExitDialog by wizardViewModel.showExitDialog.collectAsState()
 
+    // Reset to first step on every entry — on iOS the ViewModel is cached in the root
+    // ViewModelStore (no NavBackStackEntry lifecycle), so _currentStep can retain
+    // POSITIONS from the previous edit session.
+    LaunchedEffect(Unit) {
+        wizardViewModel.resetStep()
+    }
+
     AppBackHandler {
         wizardViewModel.requestBack(onNavigateBack)
     }

--- a/viewmodel/src/commonMain/kotlin/com/jesuslcorominas/teamflowmanager/viewmodel/PlayerWizardViewModel.kt
+++ b/viewmodel/src/commonMain/kotlin/com/jesuslcorominas/teamflowmanager/viewmodel/PlayerWizardViewModel.kt
@@ -168,6 +168,10 @@ class PlayerWizardViewModel(
         onNavigateBack()
     }
 
+    fun resetStep() {
+        _currentStep.value = PlayerWizardStep.PLAYER_DATA
+    }
+
     fun goToNextStep() {
         _currentStep.value = when (_currentStep.value) {
             PlayerWizardStep.PLAYER_DATA -> PlayerWizardStep.POSITIONS


### PR DESCRIPTION
## Summary

- **Root cause**: On iOS, `koinViewModel(key = playerId)` caches the ViewModel in the root `ViewModelStore`. Unlike Android (where `NavBackStackEntry` owns a fresh store per navigation entry), the iOS root store persists across navigations. After editing a player, `_currentStep` retains `POSITIONS` when re-opening the wizard for the same player.
- **Fix**: Add `PlayerWizardViewModel.resetStep()` and call it via `LaunchedEffect(Unit)` in `PlayerWizardScreen`. `LaunchedEffect(Unit)` runs once each time the composable enters composition, ensuring the step is always reset to `PLAYER_DATA` regardless of ViewModel cache state.

Closes #284

## Test plan
- [ ] Edit an existing player → wizard opens on name/number page ✅
- [ ] Navigate to positions → save → re-edit same player → still opens on name/number page ✅
- [ ] Create new player (playerId = 0) → wizard opens on name/number page ✅
- [ ] Android regression: wizard still works correctly ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)