### PR TITLE
[KMP-26] MatchCreationWizardScreen to :shared-ui (CMP-native)

### DIFF
--- a/iosApp/src/commonMain/kotlin/com/jesuslcorominas/teamflowmanager/IosNavController.kt
+++ b/iosApp/src/commonMain/kotlin/com/jesuslcorominas/teamflowmanager/IosNavController.kt
@@ -21,6 +21,7 @@ sealed class IosDestination {
     data object ClubMembers : IosDestination()
     data object Players : IosDestination()
     data class PlayerWizard(val playerId: Long) : IosDestination()
+    data class MatchWizard(val matchId: Long) : IosDestination()
     data class AcceptTeamInvitation(val teamId: String?) : IosDestination()
     data object Analysis : IosDestination()
 }

--- a/iosApp/src/commonMain/kotlin/com/jesuslcorominas/teamflowmanager/ui/App.kt
+++ b/iosApp/src/commonMain/kotlin/com/jesuslcorominas/teamflowmanager/ui/App.kt
@@ -23,6 +23,7 @@ import com.jesuslcorominas.teamflowmanager.ui.main.MainScreen
 import com.jesuslcorominas.teamflowmanager.ui.matches.ArchivedMatchesScreen
 import com.jesuslcorominas.teamflowmanager.ui.matches.MatchListScreen
 import com.jesuslcorominas.teamflowmanager.ui.matches.MatchScreen
+import com.jesuslcorominas.teamflowmanager.ui.matches.wizard.MatchCreationWizardScreen
 import com.jesuslcorominas.teamflowmanager.ui.navigation.Route
 import com.jesuslcorominas.teamflowmanager.ui.players.PlayersScreen
 import com.jesuslcorominas.teamflowmanager.ui.players.wizard.PlayerWizardScreen
@@ -75,6 +76,11 @@ fun App(
                 onNavigateBack = { navController.popBackStack() },
             )
 
+            is IosDestination.MatchWizard -> MatchCreationWizardScreen(
+                matchId = dest.matchId,
+                onNavigateBack = { navController.popBackStack() },
+            )
+
             is IosDestination.AcceptTeamInvitation -> AcceptTeamInvitationScreen(
                 teamId = dest.teamId,
                 onNavigateToLogin = { navController.navigateClearing(IosDestination.Login) },
@@ -105,7 +111,9 @@ fun App(
                                 navController.navigate(IosDestination.Team(Route.Team.MODE_CREATE))
                             is IosDestination.Players ->
                                 navController.navigate(IosDestination.PlayerWizard(0L))
-                            else -> { /* Matches FAB: KMP-26 MatchCreationWizard not yet available */ }
+                            is IosDestination.Matches ->
+                                navController.navigate(IosDestination.MatchWizard(0L))
+                            else -> {}
                         }
                     },
                     onBottomNavNavigate = { route -> navController.navigateToBottomNav(route) },
@@ -123,8 +131,8 @@ fun App(
                                 onNavigateToMatch = { match ->
                                     navController.navigate(IosDestination.Match(match.id))
                                 },
-                                onNavigateToEditMatch = {
-                                    // KMP-26: MatchCreationWizardScreen not yet available
+                                onNavigateToEditMatch = { matchId ->
+                                    navController.navigate(IosDestination.MatchWizard(matchId))
                                 },
                                 onNavigateToArchivedMatches = {
                                     navController.navigate(IosDestination.ArchivedMatches)

--- a/shared-ui/src/commonMain/kotlin/com/jesuslcorominas/teamflowmanager/ui/matches/wizard/CaptainSelectionStep.kt
+++ b/shared-ui/src/commonMain/kotlin/com/jesuslcorominas/teamflowmanager/ui/matches/wizard/CaptainSelectionStep.kt
@@ -1,0 +1,97 @@
+package com.jesuslcorominas.teamflowmanager.ui.matches.wizard
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.material3.Button
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableLongStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import com.jesuslcorominas.teamflowmanager.domain.model.Player
+import com.jesuslcorominas.teamflowmanager.ui.players.components.PlayerList
+import com.jesuslcorominas.teamflowmanager.ui.theme.TFMSpacing
+import org.jetbrains.compose.resources.stringResource
+import teamflowmanager.shared_ui.generated.resources.Res
+import teamflowmanager.shared_ui.generated.resources.captain_selection_subtitle
+import teamflowmanager.shared_ui.generated.resources.captain_selection_title
+import teamflowmanager.shared_ui.generated.resources.next
+import teamflowmanager.shared_ui.generated.resources.previous
+
+@Composable
+fun CaptainSelectionStep(
+    players: List<Player>,
+    selectedCaptainId: Long?,
+    onCaptainChanged: (Long) -> Unit,
+    onNext: () -> Unit,
+    onPrevious: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    var currentCaptainId by remember(selectedCaptainId) { mutableLongStateOf(selectedCaptainId ?: 0L) }
+
+    Column(
+        modifier = modifier.fillMaxSize(),
+        verticalArrangement = Arrangement.spacedBy(TFMSpacing.spacing03),
+    ) {
+        Text(
+            text = stringResource(Res.string.captain_selection_title),
+            style = MaterialTheme.typography.headlineSmall,
+            fontWeight = FontWeight.Bold,
+        )
+
+        Text(
+            text = stringResource(Res.string.captain_selection_subtitle),
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+
+        Spacer(modifier = Modifier.height(TFMSpacing.spacing02))
+
+        PlayerList(
+            players = players.sortedBy { it.number },
+            modifier = Modifier.weight(1F),
+            showPositions = false,
+            showGoalKeeperBadge = true,
+            paddingValues = PaddingValues(TFMSpacing.spacing02),
+            selectedPlayerIds = setOf(currentCaptainId),
+            onSingleSelectionChange = { player ->
+                currentCaptainId = player.id
+            },
+        )
+
+        Spacer(modifier = Modifier.height(TFMSpacing.spacing02))
+
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(TFMSpacing.spacing02),
+        ) {
+            Button(
+                onClick = onPrevious,
+                modifier = Modifier.weight(1f),
+            ) {
+                Text(stringResource(Res.string.previous))
+            }
+
+            Button(
+                onClick = {
+                    onCaptainChanged(currentCaptainId)
+                    onNext()
+                },
+                enabled = currentCaptainId != 0L,
+                modifier = Modifier.weight(1f),
+            ) {
+                Text(stringResource(Res.string.next))
+            }
+        }
+    }
+}

--- a/shared-ui/src/commonMain/kotlin/com/jesuslcorominas/teamflowmanager/ui/matches/wizard/GeneralDataStep.kt
+++ b/shared-ui/src/commonMain/kotlin/com/jesuslcorominas/teamflowmanager/ui/matches/wizard/GeneralDataStep.kt
@@ -1,0 +1,390 @@
+package com.jesuslcorominas.teamflowmanager.ui.matches.wizard
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.PressInteraction
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.AccessTime
+import androidx.compose.material.icons.filled.DateRange
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.DatePicker
+import androidx.compose.material3.DatePickerDialog
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.RadioButton
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TimePicker
+import androidx.compose.material3.rememberDatePickerState
+import androidx.compose.material3.rememberTimePickerState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableLongStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusDirection
+import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.KeyboardCapitalization
+import androidx.compose.ui.unit.dp
+import com.jesuslcorominas.teamflowmanager.ui.components.form.AppTextField
+import com.jesuslcorominas.teamflowmanager.ui.theme.TFMSpacing
+import com.jesuslcorominas.teamflowmanager.ui.util.DateFormatter
+import org.jetbrains.compose.resources.stringResource
+import teamflowmanager.shared_ui.generated.resources.Res
+import teamflowmanager.shared_ui.generated.resources.cancel
+import teamflowmanager.shared_ui.generated.resources.four_quarters
+import teamflowmanager.shared_ui.generated.resources.location
+import teamflowmanager.shared_ui.generated.resources.location_required
+import teamflowmanager.shared_ui.generated.resources.match_date
+import teamflowmanager.shared_ui.generated.resources.match_date_required
+import teamflowmanager.shared_ui.generated.resources.match_time
+import teamflowmanager.shared_ui.generated.resources.match_time_required
+import teamflowmanager.shared_ui.generated.resources.next
+import teamflowmanager.shared_ui.generated.resources.number_of_periods
+import teamflowmanager.shared_ui.generated.resources.opponent
+import teamflowmanager.shared_ui.generated.resources.opponent_required
+import teamflowmanager.shared_ui.generated.resources.save
+import teamflowmanager.shared_ui.generated.resources.two_halves
+import teamflowmanager.shared_ui.generated.resources.wizard_step_general_data
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun GeneralDataStep(
+    initialOpponent: String,
+    initialLocation: String,
+    initialDate: Long?,
+    initialTime: Long?,
+    initialNumberOfPeriods: Int,
+    onDataChanged: (String, String, Long?, Long?, Int) -> Unit,
+    onNext: () -> Unit,
+    onCancel: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val focusManager = LocalFocusManager.current
+
+    var opponent by remember { mutableStateOf(initialOpponent) }
+    var location by remember { mutableStateOf(initialLocation) }
+    var selectedDateMillis by remember { mutableLongStateOf(initialDate ?: 0L) }
+    var selectedTimeMillis by remember { mutableStateOf<Long?>(initialTime) }
+    var numberOfPeriods by remember { mutableIntStateOf(initialNumberOfPeriods) }
+    var opponentError by remember { mutableStateOf<String?>(null) }
+    var locationError by remember { mutableStateOf<String?>(null) }
+    var dateError by remember { mutableStateOf<String?>(null) }
+    var timeError by remember { mutableStateOf<String?>(null) }
+
+    var showDatePicker by remember { mutableStateOf(false) }
+    var showTimePicker by remember { mutableStateOf(false) }
+
+    val formattedDate = remember(selectedDateMillis) {
+        if (selectedDateMillis == 0L) "" else DateFormatter.formatDate(selectedDateMillis)
+    }
+
+    val formattedTime = remember(selectedTimeMillis) {
+        selectedTimeMillis?.let { DateFormatter.formatTimeOfDay(it) } ?: ""
+    }
+
+    Column(
+        modifier = modifier.fillMaxSize(),
+        verticalArrangement = Arrangement.spacedBy(TFMSpacing.spacing03),
+    ) {
+        Text(
+            text = stringResource(Res.string.wizard_step_general_data),
+            style = MaterialTheme.typography.headlineSmall,
+            fontWeight = FontWeight.Bold,
+        )
+
+        Spacer(modifier = Modifier.height(TFMSpacing.spacing02))
+
+        AppTextField(
+            modifier = Modifier.fillMaxWidth(),
+            value = opponent,
+            onValueChange = {
+                opponent = it
+                opponentError = null
+            },
+            label = { Text(stringResource(Res.string.opponent)) },
+            isError = opponentError != null,
+            supportingText = if (opponentError != null) {
+                { Text(opponentError!!) }
+            } else null,
+            keyboardOptions = KeyboardOptions(
+                imeAction = ImeAction.Next,
+                capitalization = KeyboardCapitalization.Words,
+            ),
+            keyboardActions = KeyboardActions(onNext = {
+                focusManager.moveFocus(FocusDirection.Down)
+            }),
+        )
+
+        AppTextField(
+            modifier = Modifier.fillMaxWidth(),
+            value = location,
+            onValueChange = {
+                location = it
+                locationError = null
+            },
+            label = { Text(stringResource(Res.string.location)) },
+            isError = locationError != null,
+            supportingText = if (locationError != null) {
+                { Text(locationError!!) }
+            } else null,
+            keyboardOptions = KeyboardOptions(
+                imeAction = ImeAction.Done,
+                capitalization = KeyboardCapitalization.Words,
+            ),
+            keyboardActions = KeyboardActions(onNext = { focusManager.clearFocus() }),
+        )
+
+        // Date Picker
+        OutlinedTextField(
+            value = formattedDate,
+            onValueChange = {},
+            label = { Text(stringResource(Res.string.match_date)) },
+            readOnly = true,
+            isError = dateError != null,
+            supportingText = if (dateError != null) {
+                { Text(dateError!!) }
+            } else null,
+            trailingIcon = {
+                IconButton(onClick = { showDatePicker = true }) {
+                    Icon(Icons.Default.DateRange, contentDescription = null)
+                }
+            },
+            modifier = Modifier.fillMaxWidth(),
+            interactionSource = remember { MutableInteractionSource() }
+                .also { interactionSource ->
+                    LaunchedEffect(interactionSource) {
+                        interactionSource.interactions.collect {
+                            if (it is PressInteraction.Release) {
+                                showDatePicker = true
+                            }
+                        }
+                    }
+                },
+        )
+
+        // Time Picker
+        OutlinedTextField(
+            value = formattedTime,
+            onValueChange = {},
+            label = { Text(stringResource(Res.string.match_time)) },
+            readOnly = true,
+            isError = timeError != null,
+            supportingText = if (timeError != null) {
+                { Text(timeError!!) }
+            } else null,
+            trailingIcon = {
+                IconButton(onClick = { showTimePicker = true }) {
+                    Icon(Icons.Default.AccessTime, contentDescription = null)
+                }
+            },
+            modifier = Modifier.fillMaxWidth(),
+            interactionSource = remember { MutableInteractionSource() }
+                .also { interactionSource ->
+                    LaunchedEffect(interactionSource) {
+                        interactionSource.interactions.collect {
+                            if (it is PressInteraction.Release) {
+                                showTimePicker = true
+                            }
+                        }
+                    }
+                },
+        )
+
+        // Number of Periods - Radio Buttons
+        Column(modifier = Modifier.fillMaxWidth()) {
+            Text(
+                text = stringResource(Res.string.number_of_periods),
+                style = MaterialTheme.typography.bodyLarge,
+                modifier = Modifier.padding(bottom = 8.dp),
+            )
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(16.dp),
+            ) {
+                // 2 Halves
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    modifier = Modifier
+                        .weight(1f)
+                        .clickable { numberOfPeriods = 2 },
+                ) {
+                    RadioButton(
+                        selected = numberOfPeriods == 2,
+                        onClick = { numberOfPeriods = 2 },
+                    )
+                    Text(
+                        text = stringResource(Res.string.two_halves),
+                        modifier = Modifier.padding(start = 8.dp),
+                    )
+                }
+
+                // 4 Quarters
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    modifier = Modifier
+                        .weight(1f)
+                        .clickable { numberOfPeriods = 4 },
+                ) {
+                    RadioButton(
+                        selected = numberOfPeriods == 4,
+                        onClick = { numberOfPeriods = 4 },
+                    )
+                    Text(
+                        text = stringResource(Res.string.four_quarters),
+                        modifier = Modifier.padding(start = 8.dp),
+                    )
+                }
+            }
+        }
+
+        Spacer(modifier = Modifier.weight(1f))
+
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(TFMSpacing.spacing02),
+        ) {
+            Button(
+                onClick = onCancel,
+                modifier = Modifier.weight(1f),
+            ) {
+                Text(stringResource(Res.string.cancel))
+            }
+
+            val opponentRequired = stringResource(Res.string.opponent_required)
+            val locationRequired = stringResource(Res.string.location_required)
+            val timeRequired = stringResource(Res.string.match_time_required)
+            val dateRequired = stringResource(Res.string.match_date_required)
+
+            Button(
+                onClick = {
+                    var hasError = false
+                    if (opponent.isBlank()) {
+                        opponentError = opponentRequired
+                        hasError = true
+                    }
+                    if (location.isBlank()) {
+                        locationError = locationRequired
+                        hasError = true
+                    }
+                    if (selectedTimeMillis == null) {
+                        timeError = timeRequired
+                        hasError = true
+                    }
+                    if (selectedDateMillis == 0L) {
+                        dateError = dateRequired
+                        hasError = true
+                    }
+
+                    if (!hasError) {
+                        onDataChanged(
+                            opponent.trimEnd(),
+                            location.trimEnd(),
+                            selectedDateMillis,
+                            selectedTimeMillis,
+                            numberOfPeriods,
+                        )
+                        onNext()
+                    }
+                },
+                modifier = Modifier.weight(1f),
+            ) {
+                Text(stringResource(Res.string.next))
+            }
+        }
+    }
+
+    // Date Picker Dialog
+    if (showDatePicker) {
+        val datePickerState = rememberDatePickerState(
+            initialSelectedDateMillis = if (selectedDateMillis == 0L) null else selectedDateMillis,
+        )
+        DatePickerDialog(
+            onDismissRequest = { showDatePicker = false },
+            confirmButton = {
+                TextButton(
+                    onClick = {
+                        datePickerState.selectedDateMillis?.let {
+                            selectedDateMillis = it
+                            dateError = null
+                        }
+                        showDatePicker = false
+                    },
+                ) {
+                    Text(stringResource(Res.string.save))
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { showDatePicker = false }) {
+                    Text(stringResource(Res.string.cancel))
+                }
+            },
+        ) {
+            DatePicker(state = datePickerState)
+        }
+    }
+
+    // Time Picker Dialog
+    if (showTimePicker) {
+        val initialHour = selectedTimeMillis?.let {
+            ((it / (60 * 60 * 1000)) % 24).toInt()
+        } ?: 0
+        val initialMinute = selectedTimeMillis?.let {
+            ((it / (60 * 1000)) % 60).toInt()
+        } ?: 0
+        val timePickerState = rememberTimePickerState(
+            initialHour = initialHour,
+            initialMinute = initialMinute,
+        )
+
+        AlertDialog(
+            onDismissRequest = { showTimePicker = false },
+            title = { Text(stringResource(Res.string.match_time)) },
+            text = {
+                TimePicker(
+                    state = timePickerState,
+                    modifier = Modifier.padding(16.dp),
+                )
+            },
+            confirmButton = {
+                TextButton(
+                    onClick = {
+                        val timeInMillis = (timePickerState.hour * 60 * 60 * 1000) +
+                            (timePickerState.minute * 60 * 1000)
+                        selectedTimeMillis = timeInMillis.toLong()
+                        timeError = null
+                        showTimePicker = false
+                    },
+                ) {
+                    Text(stringResource(Res.string.save))
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { showTimePicker = false }) {
+                    Text(stringResource(Res.string.cancel))
+                }
+            },
+        )
+    }
+}

--- a/shared-ui/src/commonMain/kotlin/com/jesuslcorominas/teamflowmanager/ui/matches/wizard/MatchCreationWizardScreen.kt
+++ b/shared-ui/src/commonMain/kotlin/com/jesuslcorominas/teamflowmanager/ui/matches/wizard/MatchCreationWizardScreen.kt
@@ -1,0 +1,190 @@
+package com.jesuslcorominas.teamflowmanager.ui.matches.wizard
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import com.jesuslcorominas.teamflowmanager.domain.analytics.ScreenName
+import com.jesuslcorominas.teamflowmanager.domain.model.Player
+import com.jesuslcorominas.teamflowmanager.ui.analytics.TrackScreenView
+import com.jesuslcorominas.teamflowmanager.ui.components.AppBackHandler
+import com.jesuslcorominas.teamflowmanager.ui.components.Loading
+import com.jesuslcorominas.teamflowmanager.ui.components.dialog.AppAlertDialog
+import com.jesuslcorominas.teamflowmanager.ui.theme.TFMSpacing
+import com.jesuslcorominas.teamflowmanager.viewmodel.MatchCreationWizardUiState
+import com.jesuslcorominas.teamflowmanager.viewmodel.MatchCreationWizardViewModel
+import com.jesuslcorominas.teamflowmanager.viewmodel.WizardStep
+import kotlinx.coroutines.launch
+import org.jetbrains.compose.resources.stringResource
+import org.koin.compose.viewmodel.koinViewModel
+import org.koin.core.parameter.parametersOf
+import teamflowmanager.shared_ui.generated.resources.Res
+import teamflowmanager.shared_ui.generated.resources.cancel
+import teamflowmanager.shared_ui.generated.resources.discard
+import teamflowmanager.shared_ui.generated.resources.discard_message
+import teamflowmanager.shared_ui.generated.resources.make_default_captain_message
+import teamflowmanager.shared_ui.generated.resources.make_default_captain_title
+import teamflowmanager.shared_ui.generated.resources.no
+import teamflowmanager.shared_ui.generated.resources.unsaved_changes_title
+import teamflowmanager.shared_ui.generated.resources.yes
+
+@Composable
+fun MatchCreationWizardScreen(
+    matchId: Long,
+    onNavigateBack: () -> Unit,
+    wizardViewModel: MatchCreationWizardViewModel = koinViewModel(parameters = { parametersOf(matchId) }),
+) {
+    TrackScreenView(screenName = ScreenName.MATCH_WIZARD, screenClass = "MatchCreationWizardScreen")
+
+    val uiState by wizardViewModel.uiState.collectAsState()
+    val currentStep by wizardViewModel.currentStep.collectAsState()
+    val showExitDialog by wizardViewModel.showExitDialog.collectAsState()
+    val scope = rememberCoroutineScope()
+
+    var showDefaultCaptainDialog by remember { mutableStateOf(false) }
+    var captainForDialog by remember { mutableStateOf<Player?>(null) }
+
+    AppBackHandler(enabled = !showExitDialog) {
+        wizardViewModel.requestBack(onNavigateBack)
+    }
+
+    when (val state = uiState) {
+        is MatchCreationWizardUiState.Loading -> Loading()
+        is MatchCreationWizardUiState.Saving -> Loading()
+        is MatchCreationWizardUiState.Ready -> {
+            Column(modifier = Modifier.fillMaxSize()) {
+                when (currentStep) {
+                    WizardStep.GENERAL_DATA -> {
+                        GeneralDataStep(
+                            initialOpponent = wizardViewModel.getOpponent(),
+                            initialLocation = wizardViewModel.getLocation(),
+                            initialDate = wizardViewModel.getDate(),
+                            initialTime = wizardViewModel.getTime(),
+                            initialNumberOfPeriods = wizardViewModel.getNumberOfPeriods(),
+                            onDataChanged = { opponent, location, date, time, numberOfPeriods ->
+                                wizardViewModel.setGeneralData(opponent, location, date, time, numberOfPeriods)
+                            },
+                            onNext = { wizardViewModel.goToNextStep() },
+                            onCancel = { wizardViewModel.requestBack(onNavigateBack) },
+                            modifier = Modifier
+                                .weight(1f)
+                                .padding(TFMSpacing.spacing04),
+                        )
+                    }
+
+                    WizardStep.SQUAD_CALLUP -> {
+                        SquadCallUpStep(
+                            players = state.players,
+                            selectedPlayerIds = wizardViewModel.getSquadCallUpIds(),
+                            minPlayers = wizardViewModel.getTeamTypePlayerCount(),
+                            onSelectionChanged = { playerIds ->
+                                wizardViewModel.setSquadCallUp(playerIds)
+                            },
+                            onNext = {
+                                wizardViewModel.goToNextStep()
+                                scope.launch { wizardViewModel.loadDefaultCaptainIfExists() }
+                            },
+                            onPrevious = { wizardViewModel.goToPreviousStep() },
+                            modifier = Modifier
+                                .weight(1f)
+                                .padding(TFMSpacing.spacing04),
+                        )
+                    }
+
+                    WizardStep.CAPTAIN -> {
+                        val squadPlayers = state.players.filter { it.id in wizardViewModel.getSquadCallUpIds() }
+                        CaptainSelectionStep(
+                            players = squadPlayers,
+                            selectedCaptainId = wizardViewModel.getCaptainId(),
+                            onCaptainChanged = { captainId ->
+                                wizardViewModel.setCaptain(captainId)
+                            },
+                            onNext = {
+                                scope.launch {
+                                    val (shouldAsk, player) = wizardViewModel.checkIfShouldAskForDefaultCaptain()
+                                    if (shouldAsk && player != null) {
+                                        captainForDialog = player
+                                        showDefaultCaptainDialog = true
+                                    } else {
+                                        wizardViewModel.goToNextStep()
+                                    }
+                                }
+                            },
+                            onPrevious = { wizardViewModel.goToPreviousStep() },
+                            modifier = Modifier
+                                .weight(1f)
+                                .padding(TFMSpacing.spacing04),
+                        )
+                    }
+
+                    WizardStep.STARTING_LINEUP -> {
+                        val squadPlayers = state.players.filter { it.id in wizardViewModel.getSquadCallUpIds() }
+                        StartingLineupStep(
+                            players = squadPlayers,
+                            selectedPlayerIds = wizardViewModel.getStartingLineupIds(),
+                            captainId = wizardViewModel.getCaptainId(),
+                            hasGoalkeepersInSquad = wizardViewModel.hasGoalkeepersInSquad(),
+                            requiredPlayers = wizardViewModel.getTeamTypePlayerCount(),
+                            onSelectionChanged = { playerIds ->
+                                wizardViewModel.setStartingLineup(playerIds)
+                            },
+                            onCreate = {
+                                if (wizardViewModel.isEditMode()) {
+                                    wizardViewModel.updateMatch { onNavigateBack() }
+                                } else {
+                                    val match = wizardViewModel.buildMatch()
+                                    wizardViewModel.createMatch(match) { onNavigateBack() }
+                                }
+                            },
+                            onPrevious = { wizardViewModel.goToPreviousStep() },
+                            modifier = Modifier
+                                .weight(1f)
+                                .padding(TFMSpacing.spacing04),
+                        )
+                    }
+                }
+            }
+        }
+    }
+
+    // Default captain dialog
+    if (showDefaultCaptainDialog && captainForDialog != null) {
+        AppAlertDialog(
+            title = stringResource(Res.string.make_default_captain_title),
+            message = stringResource(
+                Res.string.make_default_captain_message,
+                "${captainForDialog!!.firstName} ${captainForDialog!!.lastName}",
+            ),
+            confirmText = stringResource(Res.string.yes),
+            dismissText = stringResource(Res.string.no),
+            onConfirm = {
+                captainForDialog?.let { wizardViewModel.setDefaultCaptain(it.id) }
+                showDefaultCaptainDialog = false
+                wizardViewModel.goToNextStep()
+            },
+            onDismiss = {
+                showDefaultCaptainDialog = false
+                wizardViewModel.goToNextStep()
+            },
+        )
+    }
+
+    // Unsaved changes dialog
+    if (showExitDialog) {
+        AppAlertDialog(
+            title = stringResource(Res.string.unsaved_changes_title),
+            message = stringResource(Res.string.discard_message),
+            confirmText = stringResource(Res.string.discard),
+            dismissText = stringResource(Res.string.cancel),
+            onConfirm = { wizardViewModel.discardChanges(onNavigateBack) },
+            onDismiss = { wizardViewModel.dismissExitDialog() },
+        )
+    }
+}

--- a/shared-ui/src/commonMain/kotlin/com/jesuslcorominas/teamflowmanager/ui/matches/wizard/SquadCallUpStep.kt
+++ b/shared-ui/src/commonMain/kotlin/com/jesuslcorominas/teamflowmanager/ui/matches/wizard/SquadCallUpStep.kt
@@ -1,0 +1,186 @@
+package com.jesuslcorominas.teamflowmanager.ui.matches.wizard
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.Checkbox
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import com.jesuslcorominas.teamflowmanager.domain.model.Player
+import com.jesuslcorominas.teamflowmanager.domain.model.Position
+import com.jesuslcorominas.teamflowmanager.ui.components.dialog.AppAlertDialog
+import com.jesuslcorominas.teamflowmanager.ui.players.components.PlayerList
+import com.jesuslcorominas.teamflowmanager.ui.theme.TFMSpacing
+import org.jetbrains.compose.resources.stringResource
+import teamflowmanager.shared_ui.generated.resources.Res
+import teamflowmanager.shared_ui.generated.resources.next
+import teamflowmanager.shared_ui.generated.resources.no
+import teamflowmanager.shared_ui.generated.resources.previous
+import teamflowmanager.shared_ui.generated.resources.squad_callup_count
+import teamflowmanager.shared_ui.generated.resources.squad_callup_no_goalkeeper_message
+import teamflowmanager.shared_ui.generated.resources.squad_callup_no_goalkeeper_warning
+import teamflowmanager.shared_ui.generated.resources.squad_callup_select_all
+import teamflowmanager.shared_ui.generated.resources.squad_callup_subtitle
+import teamflowmanager.shared_ui.generated.resources.squad_callup_title
+import teamflowmanager.shared_ui.generated.resources.yes
+
+@Composable
+fun SquadCallUpStep(
+    players: List<Player>,
+    selectedPlayerIds: Set<Long>,
+    onSelectionChanged: (Set<Long>) -> Unit,
+    onNext: () -> Unit,
+    onPrevious: () -> Unit,
+    modifier: Modifier = Modifier,
+    minPlayers: Int = 5,
+) {
+    var currentSelection by remember(selectedPlayerIds) { mutableStateOf(selectedPlayerIds) }
+    var showGoalkeeperWarning by remember { mutableStateOf(false) }
+    var pendingNext by remember { mutableStateOf(false) }
+
+    val hasGoalkeeper = players.any { player ->
+        player.id in currentSelection && player.positions.any { it == Position.Goalkeeper }
+    }
+
+    Column(
+        modifier = modifier.fillMaxSize(),
+        verticalArrangement = Arrangement.spacedBy(TFMSpacing.spacing03),
+    ) {
+        Text(
+            text = stringResource(Res.string.squad_callup_title),
+            style = MaterialTheme.typography.headlineSmall,
+            fontWeight = FontWeight.Bold,
+        )
+
+        Text(
+            text = stringResource(Res.string.squad_callup_subtitle, minPlayers),
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+
+        Text(
+            text = stringResource(Res.string.squad_callup_count, currentSelection.size),
+            style = MaterialTheme.typography.bodyLarge,
+            fontWeight = FontWeight.Bold,
+            color = if (currentSelection.size >= minPlayers) {
+                MaterialTheme.colorScheme.primary
+            } else {
+                MaterialTheme.colorScheme.error
+            },
+        )
+
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .clickable {
+                    currentSelection = if (currentSelection.size == players.size) {
+                        emptySet()
+                    } else {
+                        players.map { it.id }.toSet()
+                    }
+                }
+                .padding(vertical = TFMSpacing.spacing02),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Checkbox(
+                checked = currentSelection.size == players.size,
+                onCheckedChange = { isChecked ->
+                    currentSelection = if (isChecked) {
+                        players.map { it.id }.toSet()
+                    } else {
+                        emptySet()
+                    }
+                },
+            )
+            Text(
+                text = stringResource(Res.string.squad_callup_select_all),
+                style = MaterialTheme.typography.bodyMedium,
+                fontWeight = FontWeight.Bold,
+                modifier = Modifier.padding(start = TFMSpacing.spacing02),
+            )
+        }
+
+        PlayerList(
+            modifier = Modifier.weight(1F),
+            paddingValues = PaddingValues(TFMSpacing.spacing02),
+            players = players.sortedBy { it.number },
+            showPositions = false,
+            showGoalKeeperBadge = true,
+            selectedPlayerIds = currentSelection,
+            onMultiSelectionChange = { player, isSelected ->
+                currentSelection = if (isSelected) {
+                    currentSelection + player.id
+                } else {
+                    currentSelection - player.id
+                }
+            },
+        )
+
+        Spacer(modifier = Modifier.height(TFMSpacing.spacing02))
+
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(TFMSpacing.spacing02),
+        ) {
+            Button(
+                onClick = onPrevious,
+                modifier = Modifier.weight(1f),
+            ) {
+                Text(stringResource(Res.string.previous))
+            }
+
+            Button(
+                onClick = {
+                    if (currentSelection.size < minPlayers) return@Button
+
+                    onSelectionChanged(currentSelection)
+
+                    if (!hasGoalkeeper) {
+                        pendingNext = true
+                        showGoalkeeperWarning = true
+                    } else {
+                        onNext()
+                    }
+                },
+                enabled = currentSelection.size >= minPlayers,
+                modifier = Modifier.weight(1f),
+            ) {
+                Text(stringResource(Res.string.next))
+            }
+        }
+    }
+
+    // Goalkeeper warning dialog
+    if (showGoalkeeperWarning) {
+        AppAlertDialog(
+            title = stringResource(Res.string.squad_callup_no_goalkeeper_warning),
+            message = stringResource(Res.string.squad_callup_no_goalkeeper_message),
+            confirmText = stringResource(Res.string.yes),
+            dismissText = stringResource(Res.string.no),
+            onConfirm = {
+                showGoalkeeperWarning = false
+                if (pendingNext) onNext()
+            },
+            onDismiss = {
+                showGoalkeeperWarning = false
+                pendingNext = false
+            },
+        )
+    }
+}

--- a/shared-ui/src/commonMain/kotlin/com/jesuslcorominas/teamflowmanager/ui/matches/wizard/StartingLineupStep.kt
+++ b/shared-ui/src/commonMain/kotlin/com/jesuslcorominas/teamflowmanager/ui/matches/wizard/StartingLineupStep.kt
@@ -1,0 +1,173 @@
+package com.jesuslcorominas.teamflowmanager.ui.matches.wizard
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.material3.Button
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import com.jesuslcorominas.teamflowmanager.domain.model.Player
+import com.jesuslcorominas.teamflowmanager.domain.model.Position
+import com.jesuslcorominas.teamflowmanager.ui.components.dialog.AppAlertDialog
+import com.jesuslcorominas.teamflowmanager.ui.players.components.PlayerList
+import com.jesuslcorominas.teamflowmanager.ui.theme.TFMSpacing
+import org.jetbrains.compose.resources.stringResource
+import teamflowmanager.shared_ui.generated.resources.Res
+import teamflowmanager.shared_ui.generated.resources.close
+import teamflowmanager.shared_ui.generated.resources.no
+import teamflowmanager.shared_ui.generated.resources.previous
+import teamflowmanager.shared_ui.generated.resources.save
+import teamflowmanager.shared_ui.generated.resources.starting_lineup_count
+import teamflowmanager.shared_ui.generated.resources.starting_lineup_max_error
+import teamflowmanager.shared_ui.generated.resources.starting_lineup_no_goalkeeper_message
+import teamflowmanager.shared_ui.generated.resources.starting_lineup_no_goalkeeper_warning
+import teamflowmanager.shared_ui.generated.resources.starting_lineup_subtitle
+import teamflowmanager.shared_ui.generated.resources.starting_lineup_title
+import teamflowmanager.shared_ui.generated.resources.yes
+
+@Composable
+fun StartingLineupStep(
+    players: List<Player>,
+    selectedPlayerIds: Set<Long>,
+    captainId: Long?,
+    hasGoalkeepersInSquad: Boolean,
+    onSelectionChanged: (Set<Long>) -> Unit,
+    onCreate: () -> Unit,
+    onPrevious: () -> Unit,
+    modifier: Modifier = Modifier,
+    requiredPlayers: Int = 5,
+) {
+    var currentSelection by remember(selectedPlayerIds) { mutableStateOf(selectedPlayerIds) }
+    var showMaxError by remember { mutableStateOf(false) }
+    var showGoalkeeperWarning by remember { mutableStateOf(false) }
+    var pendingCreate by remember { mutableStateOf(false) }
+
+    val hasGoalkeeperSelected = players.any { player ->
+        player.id in currentSelection && player.positions.any { it == Position.Goalkeeper }
+    }
+
+    Column(
+        modifier = modifier.fillMaxSize(),
+        verticalArrangement = Arrangement.spacedBy(TFMSpacing.spacing03),
+    ) {
+        Text(
+            text = stringResource(Res.string.starting_lineup_title),
+            style = MaterialTheme.typography.headlineSmall,
+            fontWeight = FontWeight.Bold,
+        )
+
+        Text(
+            text = stringResource(Res.string.starting_lineup_subtitle, requiredPlayers),
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+
+        Text(
+            text = stringResource(Res.string.starting_lineup_count, currentSelection.size, requiredPlayers),
+            style = MaterialTheme.typography.bodyLarge,
+            fontWeight = FontWeight.Bold,
+            color = if (currentSelection.size == requiredPlayers) {
+                MaterialTheme.colorScheme.primary
+            } else {
+                MaterialTheme.colorScheme.error
+            },
+        )
+
+        Spacer(modifier = Modifier.height(TFMSpacing.spacing02))
+
+        PlayerList(
+            modifier = Modifier.weight(1F),
+            players = players.sortedBy { it.number },
+            selectedPlayerIds = currentSelection,
+            showPositions = false,
+            captainId = captainId,
+            showCaptainBadge = true,
+            showGoalKeeperBadge = true,
+            paddingValues = PaddingValues(TFMSpacing.spacing02),
+            onMultiSelectionChange = { player, isSelected ->
+                if (isSelected) {
+                    if (currentSelection.size >= requiredPlayers) {
+                        showMaxError = true
+                    } else {
+                        currentSelection = currentSelection + player.id
+                    }
+                } else {
+                    currentSelection = currentSelection - player.id
+                }
+            },
+        )
+
+        Spacer(modifier = Modifier.height(TFMSpacing.spacing02))
+
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(TFMSpacing.spacing02),
+        ) {
+            Button(
+                onClick = onPrevious,
+                modifier = Modifier.weight(1f),
+            ) {
+                Text(stringResource(Res.string.previous))
+            }
+
+            Button(
+                onClick = {
+                    if (currentSelection.size != requiredPlayers) return@Button
+
+                    onSelectionChanged(currentSelection)
+
+                    if (hasGoalkeepersInSquad && !hasGoalkeeperSelected) {
+                        pendingCreate = true
+                        showGoalkeeperWarning = true
+                    } else {
+                        onCreate()
+                    }
+                },
+                enabled = currentSelection.size == requiredPlayers,
+                modifier = Modifier.weight(1f),
+            ) {
+                Text(stringResource(Res.string.save))
+            }
+        }
+    }
+
+    // Max selection error dialog
+    if (showMaxError) {
+        AppAlertDialog(
+            title = stringResource(Res.string.starting_lineup_max_error, requiredPlayers),
+            message = stringResource(Res.string.starting_lineup_max_error, requiredPlayers),
+            confirmText = stringResource(Res.string.close),
+            onConfirm = { showMaxError = false },
+        )
+    }
+
+    // Goalkeeper warning dialog
+    if (showGoalkeeperWarning) {
+        AppAlertDialog(
+            title = stringResource(Res.string.starting_lineup_no_goalkeeper_warning),
+            message = stringResource(Res.string.starting_lineup_no_goalkeeper_message),
+            confirmText = stringResource(Res.string.yes),
+            dismissText = stringResource(Res.string.no),
+            onConfirm = {
+                showGoalkeeperWarning = false
+                if (pendingCreate) onCreate()
+            },
+            onDismiss = {
+                showGoalkeeperWarning = false
+                pendingCreate = false
+            },
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- Migrates the 4-step match creation wizard (5 files, ~1,100 lines) from `app/` to `:shared-ui` commonMain
- **Key discovery**: `DatePickerDialog` and `TimePicker` (Material3 experimental) are fully available in Compose Multiplatform 1.7.3 — no expect/actual needed
- Replaced `SimpleDateFormat`/`java.util.Date` with the existing `DateFormatter` expect/actual
- Replaced `BackHandler` + `BackHandlerController` with `AppBackHandler` (existing expect/actual, iOS no-op)
- Replaced Android Koin import with CMP `org.koin.compose.viewmodel.koinViewModel`
- Removed all `@Preview` annotations

## Files created in shared-ui
- `GeneralDataStep.kt` — opponent, location, date picker, time picker, periods radio
- `CaptainSelectionStep.kt` — captain selection from squad
- `SquadCallUpStep.kt` — squad call-up with select-all checkbox
- `StartingLineupStep.kt` — starting 5 / goalkeeper validation
- `MatchCreationWizardScreen.kt` — orchestrator, VM integration, exit/captain dialogs

## iOS wiring
- `IosDestination.MatchWizard(matchId)` added
- FAB on Matches → `MatchWizard(0L)` (new match)
- `onNavigateToEditMatch` → `MatchWizard(matchId)` (edit match)

## Test plan
- [ ] Android: MatchCreationWizardScreen unchanged (app/ module unaffected)
- [ ] iOS: FAB on Matches list opens 4-step wizard
- [ ] iOS: GeneralData — opponent, location, DatePickerDialog, TimePicker, 2H/4Q radio
- [ ] iOS: SquadCallUp — checkbox select-all, goalkeeper warning dialog
- [ ] iOS: Captain — single selection, default captain dialog
- [ ] iOS: StartingLineup — exact count enforcement, goalkeeper warning, save creates match
- [ ] iOS: Edit existing match opens wizard pre-filled
- [ ] iOS: Back navigation shows unsaved-changes dialog

Closes #278

🤖 Generated with [Claude Code](https://claude.com/claude-code)