### PR TITLE
Fix: MatchCreationWizard shows stale data on iOS (VM cache)

### DIFF
--- a/shared-ui/src/commonMain/kotlin/com/jesuslcorominas/teamflowmanager/ui/matches/wizard/MatchCreationWizardScreen.kt
+++ b/shared-ui/src/commonMain/kotlin/com/jesuslcorominas/teamflowmanager/ui/matches/wizard/MatchCreationWizardScreen.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -42,6 +43,13 @@ fun MatchCreationWizardScreen(
     wizardViewModel: MatchCreationWizardViewModel = koinViewModel(parameters = { parametersOf(matchId) }),
 ) {
     TrackScreenView(screenName = ScreenName.MATCH_WIZARD, screenClass = "MatchCreationWizardScreen")
+
+    // On iOS, koinViewModel caches instances in the root ViewModelStore (no NavBackStackEntry
+    // lifecycle). Reset the wizard state each time the screen enters composition so that
+    // navigating to "new match" after editing one does not show stale data.
+    LaunchedEffect(Unit) {
+        wizardViewModel.resetForMatchId(matchId)
+    }
 
     val uiState by wizardViewModel.uiState.collectAsState()
     val currentStep by wizardViewModel.currentStep.collectAsState()

--- a/viewmodel/src/commonMain/kotlin/com/jesuslcorominas/teamflowmanager/viewmodel/MatchCreationWizardViewModel.kt
+++ b/viewmodel/src/commonMain/kotlin/com/jesuslcorominas/teamflowmanager/viewmodel/MatchCreationWizardViewModel.kt
@@ -72,6 +72,7 @@ class MatchCreationWizardViewModel(
     private var originalStartingLineupIds: Set<Long> = emptySet()
 
     private var allPlayers: List<Player> = emptyList()
+    private var activeMatchId: Long = matchId
     private var isEditMode = matchId != 0L
     private var teamTypeValue: Int = 5 // Default to Football 5
 
@@ -85,6 +86,54 @@ class MatchCreationWizardViewModel(
         loadTeam()
 
         // Load match data if in edit mode
+        if (pendingMatchIdForEdit != null) {
+            loadMatchForEdit(pendingMatchIdForEdit!!)
+        }
+    }
+
+    /**
+     * Resets all wizard state for the given matchId.
+     *
+     * Required on iOS because koinViewModel caches instances in the root
+     * ViewModelStore (no NavBackStackEntry lifecycle). Without this reset,
+     * navigating to "create new match" after editing/creating one would show
+     * the previous match data.
+     *
+     * Call via LaunchedEffect(Unit) { wizardViewModel.resetForMatchId(matchId) }
+     * in the screen composable.
+     */
+    fun resetForMatchId(newMatchId: Long) {
+        activeMatchId = newMatchId
+        isEditMode = newMatchId != 0L
+
+        opponent = ""
+        location = ""
+        date = null
+        time = null
+        numberOfPeriods = 2
+        squadCallUpIds = emptySet()
+        captainId = 0L
+        startingLineupIds = emptySet()
+
+        originalOpponent = ""
+        originalLocation = ""
+        originalDate = null
+        originalTime = null
+        originalNumberOfPeriods = 2
+        originalSquadCallUpIds = emptySet()
+        originalCaptainId = 0L
+        originalStartingLineupIds = emptySet()
+
+        _currentStep.value = WizardStep.GENERAL_DATA
+        _showExitDialog.value = false
+
+        matchDataLoaded = false
+        playersLoaded = false
+        pendingMatchIdForEdit = if (newMatchId != 0L) newMatchId else null
+
+        _uiState.value = MatchCreationWizardUiState.Loading
+        loadPlayers()
+        loadTeam()
         if (pendingMatchIdForEdit != null) {
             loadMatchForEdit(pendingMatchIdForEdit!!)
         }
@@ -317,7 +366,7 @@ class MatchCreationWizardViewModel(
         _uiState.value = MatchCreationWizardUiState.Saving
         viewModelScope.launch {
             try {
-                matchId.takeIf { it != 0L }?.let { id ->
+                activeMatchId.takeIf { it != 0L }?.let { id ->
                     crashReporter.log("Updating match via wizard: $id")
                     val existingMatch = getMatchByIdUseCase.invoke(id).firstOrNull()
                     existingMatch?.let { match ->


### PR DESCRIPTION
## Problem
On iOS, `koinViewModel` stores `MatchCreationWizardViewModel` in the root `ViewModelStore` (no `NavBackStackEntry` lifecycle). Navigating to **create new match** after having created or edited one returned the cached VM instance, still holding all data from the previous session.

## Root cause
Same iOS ViewModel caching bug class as #284 (PlayerWizard). `koinViewModel(parameters = { parametersOf(matchId) })` ignores parameters for caching — the key is always the class name.

## Fix
- **`MatchCreationWizardViewModel`**: added `resetForMatchId(newMatchId: Long)` — clears all form fields, resets step/dialogs/edit-mode flag, and re-triggers `loadPlayers()` / `loadTeam()` / `loadMatchForEdit()`. Also introduces `activeMatchId` (mutable) so `updateMatch()` uses the correct ID after a reset.
- **`MatchCreationWizardScreen`**: `LaunchedEffect(Unit)` calls `resetForMatchId(matchId)` on every composition entry.

## Test plan
- [ ] iOS: create a match → navigate back → create another match → wizard opens **empty** (not pre-filled)
- [ ] iOS: edit a match → navigate back → create new match → wizard opens **empty**
- [ ] iOS: edit a match → wizard opens **pre-filled** with correct data
- [ ] Android: match creation and edit unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)