### PR TITLE
Fix: wrap wizard screens in Scaffold to avoid iOS status bar overlap

### DIFF
--- a/shared-ui/src/commonMain/kotlin/com/jesuslcorominas/teamflowmanager/ui/matches/wizard/MatchCreationWizardScreen.kt
+++ b/shared-ui/src/commonMain/kotlin/com/jesuslcorominas/teamflowmanager/ui/matches/wizard/MatchCreationWizardScreen.kt
@@ -3,6 +3,7 @@ package com.jesuslcorominas.teamflowmanager.ui.matches.wizard
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -63,99 +64,101 @@ fun MatchCreationWizardScreen(
         wizardViewModel.requestBack(onNavigateBack)
     }
 
-    when (val state = uiState) {
-        is MatchCreationWizardUiState.Loading -> Loading()
-        is MatchCreationWizardUiState.Saving -> Loading()
-        is MatchCreationWizardUiState.Ready -> {
-            Column(modifier = Modifier.fillMaxSize()) {
-                when (currentStep) {
-                    WizardStep.GENERAL_DATA -> {
-                        GeneralDataStep(
-                            initialOpponent = wizardViewModel.getOpponent(),
-                            initialLocation = wizardViewModel.getLocation(),
-                            initialDate = wizardViewModel.getDate(),
-                            initialTime = wizardViewModel.getTime(),
-                            initialNumberOfPeriods = wizardViewModel.getNumberOfPeriods(),
-                            onDataChanged = { opponent, location, date, time, numberOfPeriods ->
-                                wizardViewModel.setGeneralData(opponent, location, date, time, numberOfPeriods)
-                            },
-                            onNext = { wizardViewModel.goToNextStep() },
-                            onCancel = { wizardViewModel.requestBack(onNavigateBack) },
-                            modifier = Modifier
-                                .weight(1f)
-                                .padding(TFMSpacing.spacing04),
-                        )
-                    }
+    Scaffold { paddingValues ->
+        when (val state = uiState) {
+            is MatchCreationWizardUiState.Loading -> Loading()
+            is MatchCreationWizardUiState.Saving -> Loading()
+            is MatchCreationWizardUiState.Ready -> {
+                Column(modifier = Modifier.fillMaxSize().padding(paddingValues)) {
+                    when (currentStep) {
+                        WizardStep.GENERAL_DATA -> {
+                            GeneralDataStep(
+                                initialOpponent = wizardViewModel.getOpponent(),
+                                initialLocation = wizardViewModel.getLocation(),
+                                initialDate = wizardViewModel.getDate(),
+                                initialTime = wizardViewModel.getTime(),
+                                initialNumberOfPeriods = wizardViewModel.getNumberOfPeriods(),
+                                onDataChanged = { opponent, location, date, time, numberOfPeriods ->
+                                    wizardViewModel.setGeneralData(opponent, location, date, time, numberOfPeriods)
+                                },
+                                onNext = { wizardViewModel.goToNextStep() },
+                                onCancel = { wizardViewModel.requestBack(onNavigateBack) },
+                                modifier = Modifier
+                                    .weight(1f)
+                                    .padding(TFMSpacing.spacing04),
+                            )
+                        }
 
-                    WizardStep.SQUAD_CALLUP -> {
-                        SquadCallUpStep(
-                            players = state.players,
-                            selectedPlayerIds = wizardViewModel.getSquadCallUpIds(),
-                            minPlayers = wizardViewModel.getTeamTypePlayerCount(),
-                            onSelectionChanged = { playerIds ->
-                                wizardViewModel.setSquadCallUp(playerIds)
-                            },
-                            onNext = {
-                                wizardViewModel.goToNextStep()
-                                scope.launch { wizardViewModel.loadDefaultCaptainIfExists() }
-                            },
-                            onPrevious = { wizardViewModel.goToPreviousStep() },
-                            modifier = Modifier
-                                .weight(1f)
-                                .padding(TFMSpacing.spacing04),
-                        )
-                    }
+                        WizardStep.SQUAD_CALLUP -> {
+                            SquadCallUpStep(
+                                players = state.players,
+                                selectedPlayerIds = wizardViewModel.getSquadCallUpIds(),
+                                minPlayers = wizardViewModel.getTeamTypePlayerCount(),
+                                onSelectionChanged = { playerIds ->
+                                    wizardViewModel.setSquadCallUp(playerIds)
+                                },
+                                onNext = {
+                                    wizardViewModel.goToNextStep()
+                                    scope.launch { wizardViewModel.loadDefaultCaptainIfExists() }
+                                },
+                                onPrevious = { wizardViewModel.goToPreviousStep() },
+                                modifier = Modifier
+                                    .weight(1f)
+                                    .padding(TFMSpacing.spacing04),
+                            )
+                        }
 
-                    WizardStep.CAPTAIN -> {
-                        val squadPlayers = state.players.filter { it.id in wizardViewModel.getSquadCallUpIds() }
-                        CaptainSelectionStep(
-                            players = squadPlayers,
-                            selectedCaptainId = wizardViewModel.getCaptainId(),
-                            onCaptainChanged = { captainId ->
-                                wizardViewModel.setCaptain(captainId)
-                            },
-                            onNext = {
-                                scope.launch {
-                                    val (shouldAsk, player) = wizardViewModel.checkIfShouldAskForDefaultCaptain()
-                                    if (shouldAsk && player != null) {
-                                        captainForDialog = player
-                                        showDefaultCaptainDialog = true
-                                    } else {
-                                        wizardViewModel.goToNextStep()
+                        WizardStep.CAPTAIN -> {
+                            val squadPlayers = state.players.filter { it.id in wizardViewModel.getSquadCallUpIds() }
+                            CaptainSelectionStep(
+                                players = squadPlayers,
+                                selectedCaptainId = wizardViewModel.getCaptainId(),
+                                onCaptainChanged = { captainId ->
+                                    wizardViewModel.setCaptain(captainId)
+                                },
+                                onNext = {
+                                    scope.launch {
+                                        val (shouldAsk, player) = wizardViewModel.checkIfShouldAskForDefaultCaptain()
+                                        if (shouldAsk && player != null) {
+                                            captainForDialog = player
+                                            showDefaultCaptainDialog = true
+                                        } else {
+                                            wizardViewModel.goToNextStep()
+                                        }
                                     }
-                                }
-                            },
-                            onPrevious = { wizardViewModel.goToPreviousStep() },
-                            modifier = Modifier
-                                .weight(1f)
-                                .padding(TFMSpacing.spacing04),
-                        )
-                    }
+                                },
+                                onPrevious = { wizardViewModel.goToPreviousStep() },
+                                modifier = Modifier
+                                    .weight(1f)
+                                    .padding(TFMSpacing.spacing04),
+                            )
+                        }
 
-                    WizardStep.STARTING_LINEUP -> {
-                        val squadPlayers = state.players.filter { it.id in wizardViewModel.getSquadCallUpIds() }
-                        StartingLineupStep(
-                            players = squadPlayers,
-                            selectedPlayerIds = wizardViewModel.getStartingLineupIds(),
-                            captainId = wizardViewModel.getCaptainId(),
-                            hasGoalkeepersInSquad = wizardViewModel.hasGoalkeepersInSquad(),
-                            requiredPlayers = wizardViewModel.getTeamTypePlayerCount(),
-                            onSelectionChanged = { playerIds ->
-                                wizardViewModel.setStartingLineup(playerIds)
-                            },
-                            onCreate = {
-                                if (wizardViewModel.isEditMode()) {
-                                    wizardViewModel.updateMatch { onNavigateBack() }
-                                } else {
-                                    val match = wizardViewModel.buildMatch()
-                                    wizardViewModel.createMatch(match) { onNavigateBack() }
-                                }
-                            },
-                            onPrevious = { wizardViewModel.goToPreviousStep() },
-                            modifier = Modifier
-                                .weight(1f)
-                                .padding(TFMSpacing.spacing04),
-                        )
+                        WizardStep.STARTING_LINEUP -> {
+                            val squadPlayers = state.players.filter { it.id in wizardViewModel.getSquadCallUpIds() }
+                            StartingLineupStep(
+                                players = squadPlayers,
+                                selectedPlayerIds = wizardViewModel.getStartingLineupIds(),
+                                captainId = wizardViewModel.getCaptainId(),
+                                hasGoalkeepersInSquad = wizardViewModel.hasGoalkeepersInSquad(),
+                                requiredPlayers = wizardViewModel.getTeamTypePlayerCount(),
+                                onSelectionChanged = { playerIds ->
+                                    wizardViewModel.setStartingLineup(playerIds)
+                                },
+                                onCreate = {
+                                    if (wizardViewModel.isEditMode()) {
+                                        wizardViewModel.updateMatch { onNavigateBack() }
+                                    } else {
+                                        val match = wizardViewModel.buildMatch()
+                                        wizardViewModel.createMatch(match) { onNavigateBack() }
+                                    }
+                                },
+                                onPrevious = { wizardViewModel.goToPreviousStep() },
+                                modifier = Modifier
+                                    .weight(1f)
+                                    .padding(TFMSpacing.spacing04),
+                            )
+                        }
                     }
                 }
             }

--- a/shared-ui/src/commonMain/kotlin/com/jesuslcorominas/teamflowmanager/ui/players/wizard/PlayerWizardScreen.kt
+++ b/shared-ui/src/commonMain/kotlin/com/jesuslcorominas/teamflowmanager/ui/players/wizard/PlayerWizardScreen.kt
@@ -3,6 +3,7 @@ package com.jesuslcorominas.teamflowmanager.ui.players.wizard
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -52,79 +53,81 @@ fun PlayerWizardScreen(
         wizardViewModel.requestBack(onNavigateBack)
     }
 
-    when (uiState) {
-        is PlayerWizardUiState.Loading -> Loading()
-        is PlayerWizardUiState.Error -> {
-            LaunchedEffect(Unit) { onNavigateBack() }
-        }
-        is PlayerWizardUiState.Ready -> {
-            Column(modifier = Modifier.fillMaxSize()) {
-                when (currentStep) {
-                    PlayerWizardStep.PLAYER_DATA -> {
-                        PlayerDataStep(
-                            initialFirstName = wizardViewModel.getFirstName(),
-                            initialLastName = wizardViewModel.getLastName(),
-                            initialNumber = wizardViewModel.getNumber(),
-                            initialIsCaptain = wizardViewModel.getIsCaptain(),
-                            initialImageUri = wizardViewModel.getImageUri(),
-                            onDataChanged = { firstName, lastName, number, isCaptain, imageUri ->
-                                wizardViewModel.setPlayerData(firstName, lastName, number, isCaptain, imageUri)
-                            },
-                            onNext = { wizardViewModel.goToNextStep() },
-                            onCancel = { wizardViewModel.requestBack(onNavigateBack) },
-                            modifier = Modifier
-                                .weight(1f)
-                                .padding(TFMSpacing.spacing04),
-                        )
-                    }
-                    PlayerWizardStep.POSITIONS -> {
-                        PlayerPositionsStep(
-                            initialPositions = wizardViewModel.getSelectedPositions(),
-                            onPositionsChanged = { positions -> wizardViewModel.setPositions(positions) },
-                            onSave = { wizardViewModel.savePlayer(onSuccess = onNavigateBack) },
-                            onPrevious = { wizardViewModel.goToPreviousStep() },
-                            modifier = Modifier
-                                .weight(1f)
-                                .padding(TFMSpacing.spacing04),
-                        )
+    Scaffold { paddingValues ->
+        when (uiState) {
+            is PlayerWizardUiState.Loading -> Loading()
+            is PlayerWizardUiState.Error -> {
+                LaunchedEffect(Unit) { onNavigateBack() }
+            }
+            is PlayerWizardUiState.Ready -> {
+                Column(modifier = Modifier.fillMaxSize().padding(paddingValues)) {
+                    when (currentStep) {
+                        PlayerWizardStep.PLAYER_DATA -> {
+                            PlayerDataStep(
+                                initialFirstName = wizardViewModel.getFirstName(),
+                                initialLastName = wizardViewModel.getLastName(),
+                                initialNumber = wizardViewModel.getNumber(),
+                                initialIsCaptain = wizardViewModel.getIsCaptain(),
+                                initialImageUri = wizardViewModel.getImageUri(),
+                                onDataChanged = { firstName, lastName, number, isCaptain, imageUri ->
+                                    wizardViewModel.setPlayerData(firstName, lastName, number, isCaptain, imageUri)
+                                },
+                                onNext = { wizardViewModel.goToNextStep() },
+                                onCancel = { wizardViewModel.requestBack(onNavigateBack) },
+                                modifier = Modifier
+                                    .weight(1f)
+                                    .padding(TFMSpacing.spacing04),
+                            )
+                        }
+                        PlayerWizardStep.POSITIONS -> {
+                            PlayerPositionsStep(
+                                initialPositions = wizardViewModel.getSelectedPositions(),
+                                onPositionsChanged = { positions -> wizardViewModel.setPositions(positions) },
+                                onSave = { wizardViewModel.savePlayer(onSuccess = onNavigateBack) },
+                                onPrevious = { wizardViewModel.goToPreviousStep() },
+                                modifier = Modifier
+                                    .weight(1f)
+                                    .padding(TFMSpacing.spacing04),
+                            )
+                        }
                     }
                 }
-            }
 
-            when (val state = captainConfirmationState) {
-                is CaptainConfirmationState.ConfirmReplace -> CaptainConfirmationDialog(
-                    state = state,
-                    onConfirm = { wizardViewModel.confirmCaptainChange(onSuccess = onNavigateBack) },
-                    onDismiss = { wizardViewModel.cancelCaptainChange() },
-                )
-                is CaptainConfirmationState.ConfirmReplaceWithMatches -> CaptainConfirmationDialog(
-                    state = state,
-                    onConfirm = { keepInMatches -> wizardViewModel.confirmCaptainChange(keepInMatches, onSuccess = onNavigateBack) },
-                    onDismiss = { wizardViewModel.cancelCaptainChange() },
-                )
-                is CaptainConfirmationState.ConfirmRemove -> CaptainConfirmationDialog(
-                    state = state,
-                    onConfirm = { wizardViewModel.confirmCaptainChange(onSuccess = onNavigateBack) },
-                    onDismiss = { wizardViewModel.cancelCaptainChange() },
-                )
-                is CaptainConfirmationState.ConfirmRemoveWithMatches -> CaptainConfirmationDialog(
-                    state = state,
-                    onConfirm = { keepInMatches -> wizardViewModel.confirmCaptainChange(keepInMatches, onSuccess = onNavigateBack) },
-                    onDismiss = { wizardViewModel.cancelCaptainChange() },
-                )
-                is CaptainConfirmationState.None -> {}
+                when (val state = captainConfirmationState) {
+                    is CaptainConfirmationState.ConfirmReplace -> CaptainConfirmationDialog(
+                        state = state,
+                        onConfirm = { wizardViewModel.confirmCaptainChange(onSuccess = onNavigateBack) },
+                        onDismiss = { wizardViewModel.cancelCaptainChange() },
+                    )
+                    is CaptainConfirmationState.ConfirmReplaceWithMatches -> CaptainConfirmationDialog(
+                        state = state,
+                        onConfirm = { keepInMatches -> wizardViewModel.confirmCaptainChange(keepInMatches, onSuccess = onNavigateBack) },
+                        onDismiss = { wizardViewModel.cancelCaptainChange() },
+                    )
+                    is CaptainConfirmationState.ConfirmRemove -> CaptainConfirmationDialog(
+                        state = state,
+                        onConfirm = { wizardViewModel.confirmCaptainChange(onSuccess = onNavigateBack) },
+                        onDismiss = { wizardViewModel.cancelCaptainChange() },
+                    )
+                    is CaptainConfirmationState.ConfirmRemoveWithMatches -> CaptainConfirmationDialog(
+                        state = state,
+                        onConfirm = { keepInMatches -> wizardViewModel.confirmCaptainChange(keepInMatches, onSuccess = onNavigateBack) },
+                        onDismiss = { wizardViewModel.cancelCaptainChange() },
+                    )
+                    is CaptainConfirmationState.None -> {}
+                }
             }
         }
-    }
 
-    if (showExitDialog) {
-        AppAlertDialog(
-            title = stringResource(Res.string.unsaved_changes_title),
-            message = stringResource(Res.string.discard_message),
-            confirmText = stringResource(Res.string.discard),
-            dismissText = stringResource(Res.string.cancel),
-            onConfirm = { wizardViewModel.discardChanges(onNavigateBack) },
-            onDismiss = { wizardViewModel.dismissExitDialog() },
-        )
+        if (showExitDialog) {
+            AppAlertDialog(
+                title = stringResource(Res.string.unsaved_changes_title),
+                message = stringResource(Res.string.discard_message),
+                confirmText = stringResource(Res.string.discard),
+                dismissText = stringResource(Res.string.cancel),
+                onConfirm = { wizardViewModel.discardChanges(onNavigateBack) },
+                onDismiss = { wizardViewModel.dismissExitDialog() },
+            )
+        }
     }
 }


### PR DESCRIPTION
## Summary
- `MatchCreationWizardScreen` and `PlayerWizardScreen` are full-screen destinations rendered outside `MainScreen`'s Scaffold, so they received no safe-area inset padding
- Wrapped each screen's content in its own `Scaffold { paddingValues -> ... .padding(paddingValues) }` — same pattern used by `LoginScreen`

## Test plan
- [ ] Open match creation wizard on iOS → title appears below status bar
- [ ] Open match edit wizard on iOS → same
- [ ] Open player creation wizard on iOS → same
- [ ] Verify dialogs (unsaved changes, captain confirmation) still appear correctly
- [ ] Verify Android builds unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)