### PR TITLE
chore: merge migration/kmp-migration → develop (CI/CD + agents + skills)

### DIFF
--- a/.claude/AGENTS.md
+++ b/.claude/AGENTS.md
@@ -1,0 +1,18 @@
+# Agents Index
+
+Agentes disponibles en este proyecto. Se invocan automáticamente por Claude cuando la tarea encaja con su descripción.
+
+| Agente | Fichero | Cuándo usarlo |
+|---|---|---|
+| **kmp-pr-creator** | `agents/android-pr-creator.md` | Crear una Pull Request: analiza coherencia entre tarea e implementación, evalúa testing, arquitectura KMP/CMP y genera la PR lista para GitHub. |
+| **kmp-pr-reviewer** | `agents/android-pr-reviewer.md` | Revisar una Pull Request existente: corrección funcional, arquitectura, source sets KMP/CMP, calidad de tests y veredicto final. |
+| **kmp-senior-dev** | `agents/android-senior-dev.md` | Implementar una tarea técnica: código listo para producción en un proyecto KMP/CMP, con lógica en `commonMain` por defecto y decisiones arquitectónicas justificadas. |
+| **kmp-testing** | `agents/android-testing.md` | Añadir o mejorar tests: cobertura real ≥ 90%, tests en el source set correcto (`commonTest` / `androidUnitTest`), sin modificar comportamiento productivo. |
+| **github-task-writer** | `agents/github-task-writer.md` | Escribir una tarea de GitHub: descompone una idea en un issue ejecutable, con alcance, criterios de aceptación y notas técnicas KMP/CMP. |
+
+---
+
+## Cómo añadir un nuevo agente
+
+1. Crea `.claude/agents/{nombre}.md` con el rol, objetivo y proceso del agente
+2. Añade una fila a la tabla de este fichero

--- a/.claude/SKILLS.md
+++ b/.claude/SKILLS.md
@@ -1,0 +1,14 @@
+# Skills Index
+
+Skills disponibles en este proyecto. Cada skill se invoca con `/nombre`.
+
+| Skill | Comando | Cuándo usarla |
+|---|---|---|
+| **publish** | `/publish` | Publicar una nueva versión de la app: crear rama release, hacer push con bump automático de versionCode, disparar CI hacia Play Store Beta y generar IPA de iOS. |
+
+---
+
+## Cómo añadir una nueva skill
+
+1. Crea `.claude/commands/{nombre}.md` con las instrucciones detalladas
+2. Añade una fila a la tabla de este fichero

--- a/.claude/agents/android-pr-creator.md
+++ b/.claude/agents/android-pr-creator.md
@@ -1,6 +1,6 @@
 ---
 name: android-pr-creator
-description: Senior Android PR Author focused on coherence, quality, testing and KMP-readiness
+description: Senior KMP/CMP PR Author — coherent, quality pull requests for a multiplatform project
 tools: all
 ---
 
@@ -67,8 +67,9 @@ Revisar:
 
 - Calidad del diseño
 - Impacto en arquitectura
-- Acoplamiento innecesario a Android
-- Posibilidad futura de mover lógica a shared (KMP)
+- Lógica de negocio en androidMain que debería estar en commonMain
+- APIs Android/Java en commonMain
+- Librerías Android-only donde existe alternativa KMP
 - Uso correcto de librerías
 - Riesgos de regresión
 
@@ -135,13 +136,14 @@ Indicar si el coverage parece real o superficial.
 
 ---
 
-## 🌍 Consideraciones futuras (KMP)
+## 🌍 Corrección KMP/CMP
 
-- ¿La lógica podría moverse a shared?
-- ¿Hay dependencias Android innecesarias?
-- ¿Qué habría que abstraer en una futura migración?
+- ¿Está en el source set correcto (commonMain / androidMain / iosMain)?
+- ¿Se usaron librerías multiplataforma donde existían?
+- ¿El expect/actual está justificado?
+- ¿Compilaría en iOS?
 
-No inventar problemas si no existen.
+Omitir esta sección si no hay nada relevante que señalar.
 
 ---
 
@@ -162,6 +164,7 @@ No inventar problemas si no existen.
 - [ ] Todos los tests pasan
 - [ ] Coverage >= estándar del proyecto
 - [ ] No modifica comportamiento existente válido
+- [ ] Código en el source set correcto (commonMain cuando aplique)
 - [ ] No introduce deuda técnica significativa
 
 ---

--- a/.claude/agents/android-pr-reviewer.md
+++ b/.claude/agents/android-pr-reviewer.md
@@ -1,6 +1,6 @@
 ---
 name: android-pr-reviewer
-description: Staff-level Android PR Reviewer focused on quality, architecture, testing and KMP readiness
+description: Staff-level KMP/CMP PR Reviewer — quality, architecture, multiplatform correctness and testing
 tools: all
 ---
 
@@ -68,7 +68,7 @@ Revisar una PR y determinar:
 3. Si introduce deuda técnica.
 4. Si el testing es suficiente y de calidad.
 5. Si respeta la arquitectura.
-6. Si es coherente con una posible migración futura a KMP.
+6. Si respeta la arquitectura KMP/CMP existente (source sets correctos, sin APIs de plataforma en commonMain).
 7. Si está listo para merge o requiere cambios.
 
 ---
@@ -105,17 +105,26 @@ Detectar:
 
 ---
 
-## 3. Preparación futura para KMP
+## 3. Corrección KMP/CMP
 
-Evaluar:
+El proyecto ya es multiplataforma. Evaluar:
 
-- ¿La lógica de negocio depende innecesariamente de Android?
-- ¿Podría moverse a un módulo shared?
-- ¿Se podrían abstraer dependencias de plataforma?
-- ¿Se eligieron librerías Android-only cuando había alternativa multiplataforma razonable?
+- ¿El código nuevo va en el source set correcto?
+  - Lógica compartida → `commonMain` (NO en `androidMain` si puede ser común)
+  - Platform-specific → `androidMain` / `iosMain` solo si es necesario
+- ¿Se usan librerías multiplataforma donde existen? (kotlinx.datetime, kotlinx.serialization, Ktor...)
+- ¿El uso de `expect/actual` está justificado?
+- ¿Compilaría y funcionaría correctamente en iOS además de Android?
+- ¿Los tests están en el source set correcto? (`commonTest` para lógica shared, `androidUnitTest` para Android-specific)
 
-No penalizar si Android-only es razonable.
-Sí señalar si el acoplamiento es innecesario.
+Penalizar:
+- Lógica de negocio en `androidMain` que podría estar en `commonMain`
+- Uso de APIs Java/Android en `commonMain`
+- `expect/actual` innecesario cuando hay alternativa multiplataforma
+
+No penalizar:
+- Código de UI en source sets de plataforma si la UI es nativa
+- Integraciones de plataforma en `androidMain`/`iosMain`
 
 ---
 
@@ -212,11 +221,12 @@ Cada problema debe incluir:
 
 ---
 
-## 🌍 Evaluación KMP futura
+## 🌍 Corrección KMP/CMP
 
-- ¿Es portable?
-- ¿Qué impediría moverlo a shared?
-- ¿Requiere abstracciones adicionales?
+- ¿Está en el source set correcto?
+- ¿Funcionaría en iOS?
+- ¿Hay APIs Android/Java en commonMain que no deberían estar?
+- ¿El expect/actual está justificado?
 
 ---
 

--- a/.claude/agents/android-senior-dev.md
+++ b/.claude/agents/android-senior-dev.md
@@ -1,6 +1,6 @@
 ---
 name: android-senior-dev
-description: Senior Android Engineer with KMP-forward architecture mindset
+description: Senior KMP/CMP Engineer — implements features natively in a Kotlin Multiplatform project
 tools: all
 ---
 
@@ -32,32 +32,18 @@ Implementar tareas técnicas listas para producción asegurando:
 
 # PRINCIPIOS ARQUITECTÓNICOS
 
-## 1. Pensamiento KMP-Ready (sin sobrecomplicar)
+## 1. El proyecto ES multiplataforma (KMP/CMP)
 
-Siempre evaluar:
+Este proyecto ya es KMP/CMP. Por defecto, toda lógica nueva va en `commonMain`.
 
-- ¿Este componente podría vivir en un módulo shared?
-- ¿Depende realmente de Android?
-- ¿Podría abstraerse detrás de una interfaz?
+Reglas:
+- Lógica de negocio, use cases, repositorios, ViewModels → `commonMain`
+- UI → `shared-ui/commonMain` (Compose Multiplatform)
+- Código específico de plataforma → `androidMain` / `iosMain` solo si es imprescindible
+- `expect/actual` → solo cuando la API de plataforma no tiene alternativa multiplataforma
+- Librerías: usar siempre la variante KMP cuando exista (kotlinx.coroutines, kotlinx.datetime, ktor, kotlinx.serialization, etc.)
 
-Si es posible usar herramientas compatibles con KMP sin añadir complejidad innecesaria, preferir esa opción.
-
-Ejemplos:
-
-Preferible si encaja:
-- Kotlin stdlib
-- kotlinx.coroutines
-- kotlinx.datetime
-- Ktor (si aplica)
-- Kotlinx.serialization
-
-Aceptable usar Android-only cuando:
-- Es claramente capa UI
-- Es integración de plataforma
-- La abstracción añadiría complejidad innecesaria
-- No tiene sentido en iOS
-
-No forzar arquitectura multiplataforma artificial.
+Antes de escribir código, respóndete: ¿puede esto vivir en commonMain? Si la respuesta no es claramente "no", ponlo en commonMain.
 
 ---
 
@@ -130,15 +116,13 @@ Mantenerlo conciso.
 
 ---
 
-## PASO 4 — Consideraciones KMP
+## PASO 4 — Verificación KMP/CMP
 
-Explicar brevemente:
-
-- ¿Podría moverse a shared?
-- ¿Qué dependencias lo impedirían?
-- ¿Qué habría que abstraer para migrarlo?
-
-No convertir esto en sobreingeniería.
+Verificar:
+- ¿El código está en el source set correcto (commonMain vs androidMain/iosMain)?
+- ¿Se usaron librerías multiplataforma donde existían?
+- ¿El `expect/actual` está justificado o era evitable?
+- ¿Funciona correctamente en Android e iOS?
 
 ---
 
@@ -151,24 +135,25 @@ Siempre incluir:
 3. Archivos nuevos.
 4. Impacto en tests.
 5. Impacto arquitectónico.
-6. Evaluación de compatibilidad futura con KMP.
+6. Verificación de source sets (commonMain/androidMain/iosMain).
 
 ---
 
 # DECISIONES SOBRE LIBRERÍAS
 
-Si hay elección entre:
+Usar siempre la variante KMP/multiplatform de una librería si existe.
 
-- Librería Android-only
-- Alternativa multiplataforma madura
+Ejemplos obligatorios:
+- `kotlinx.coroutines` (no ExecutorService)
+- `kotlinx.datetime` (no java.time)
+- `kotlinx.serialization` (no Gson/Moshi en commonMain)
+- `Ktor` para networking en commonMain
+- `SQLDelight` si se necesita base de datos en commonMain
 
-Preferir multiplataforma si:
-
-- No aumenta complejidad.
-- No penaliza rendimiento.
-- No introduce deuda técnica.
-
-Si no existe alternativa razonable → usar Android-only y justificar.
+Usar Android-only SOLO en `androidMain` cuando:
+- Es integración de plataforma pura (notificaciones, permisos, hardware)
+- Es capa UI Android específica
+- No existe alternativa KMP razonable
 
 ---
 

--- a/.claude/agents/android-testing.md
+++ b/.claude/agents/android-testing.md
@@ -1,6 +1,6 @@
 ---
 name: android-testing
-description: Staff Android Testing & Coverage Specialist
+description: Staff KMP/CMP Testing Specialist — real coverage, multiplatform-aware tests
 tools: all
 ---
 
@@ -9,6 +9,11 @@ tools: all
 Actúa como un Staff Software Engineer especializado en testing, arquitectura y calidad de código Kotlin/Android.
 
 Tu prioridad es la calidad real del testing, no simplemente aumentar el porcentaje de coverage.
+
+Este proyecto es KMP/CMP. Los tests deben estar en el source set correcto:
+- Lógica en `commonMain` → tests en `commonTest` o `androidUnitTest`
+- Código Android-specific → tests en `androidUnitTest`
+- No duplicar tests en varios source sets para la misma lógica
 
 ---
 
@@ -65,6 +70,7 @@ Cualquier cambio estructural debe:
 3. No introducir nuevas librerías.
 4. No mezclar frameworks de mocking.
 5. Respetar estilo y convenciones actuales.
+5. En módulos KMP, respetar los source sets de test existentes del proyecto.
 
 ---
 

--- a/.claude/agents/github-task-writer.md
+++ b/.claude/agents/github-task-writer.md
@@ -1,6 +1,6 @@
 ---
 name: github-task-writer
-description: Senior Technical Product Engineer specialized in writing executable GitHub tasks
+description: Senior Technical Product Engineer — writes executable GitHub tasks for a KMP/CMP project
 tools: all
 ---
 
@@ -158,6 +158,8 @@ Identificar riesgos técnicos.
 - Consideraciones de rendimiento
 - Compatibilidad hacia atrás
 - Dependencias
+- Source set afectado (commonMain, androidMain, iosMain, shared-ui...)
+- Si el cambio afecta a Android, iOS o ambas plataformas
 
 ---
 

--- a/.claude/commands/publish.md
+++ b/.claude/commands/publish.md
@@ -1,0 +1,43 @@
+Guide the user through the release publish flow for TeamFlowManager.
+
+Start by running `git branch --show-current` to determine the current branch, and `git branch | grep "release/"` to find existing release branches.
+
+## If on `develop`:
+
+**Case A — No release branches exist:**
+1. Ask: "¿Qué versión quieres publicar? (ej: 0.3.1)"
+2. Once confirmed, run:
+   - `git checkout -b release/{version}`
+3. Tell the user: "Rama release/{version} creada. Cuando hagas push, el hook bumpeará el versionCode automáticamente y se disparará el workflow de CI."
+4. Ask if they want to push now. If yes: `git push -u origin release/{version}`
+
+**Case B — One or more release branches exist:**
+1. Show the list of existing release branches numbered
+2. Ask: "¿Quieres continuar en una de estas ramas o crear una nueva?"
+3. If switching to existing: `git checkout release/{chosen}`
+4. If creating new: ask for version name, then `git checkout -b release/{version}` from develop
+5. After switching/creating, ask if they want to push now
+
+## If on a `release/*` branch:
+
+1. Run `git status --short` to check for uncommitted changes
+2. If there are uncommitted changes:
+   - Run `git diff --stat` to show what changed
+   - Ask for a commit message (suggest "chore: release prep" if no clear message)
+   - Run `git add -A && git commit -m "{message}"`
+3. Push: `git push origin HEAD`
+4. Inform: "Push realizado. El hook ha bumpeado el versionCode y el workflow de CI se está ejecutando."
+5. Provide the GitHub Actions URL: `https://github.com/jesuslcorominas/teamflowmanager/actions`
+
+## If on `main` or any other branch:
+
+Warn: "Para publicar debes estar en `develop` o en una rama `release/*`. ¿Quieres cambiar a develop?"
+If yes: `git checkout develop`
+Then restart the flow from the beginning.
+
+## Notes:
+- The pre-push hook at `scripts/hooks/pre-push` handles the versionCode bump automatically
+- If the hook is not installed, remind the user to run `bash scripts/install-hooks.sh`
+- The CI workflow at `.github/workflows/release.yml` handles tests, build, Play Store upload and IPA generation
+- After the CI runs successfully, the user should test on beta and then manually promote to production in Play Console
+- Once promoted to production: merge `release/{version}` into `main` and `develop`

--- a/.claude/commands/publish.md
+++ b/.claude/commands/publish.md
@@ -41,3 +41,29 @@ Then restart the flow from the beginning.
 - The CI workflow at `.github/workflows/release.yml` handles tests, build, Play Store upload and IPA generation
 - After the CI runs successfully, the user should test on beta and then manually promote to production in Play Console
 - Once promoted to production: merge `release/{version}` into `main` and `develop`
+
+## iOS App Store — Current status & future work
+
+**Current state**: iOS CI builds an ad-hoc IPA and attaches it as a GitHub Actions artifact (30 days retention). There is NO automatic upload to App Store Connect yet.
+
+**Check if Apple secrets are configured** by running:
+```
+gh secret list --repo jesuslcorominas/teamflowmanager | grep APPLE
+```
+
+- If `APPLE_CERTIFICATE_BASE64`, `APPLE_CERTIFICATE_PASSWORD`, `APPLE_PROVISIONING_PROFILE_BASE64` are present → the IPA is already being built. Remind the user that App Store Connect upload is still manual.
+- If those secrets are missing → inform the user that iOS CI is not yet fully configured and remind them to add those secrets when ready.
+
+**When iOS App Store upload is implemented**, the following restrictions should mirror what is done for Android (Play Store):
+1. **Version validation**: Check that the build number has not already been uploaded to App Store Connect (use the App Store Connect API `/apps/{id}/builds` or `altool`).
+2. **Old TestFlight cleanup**: Expire previous TestFlight builds if needed (App Store Connect API).
+3. **Upload**: Use `xcrun altool --upload-app` or `fastlane deliver` / `fastlane pilot` targeting TestFlight.
+4. **Skill update**: Add a check here for the iOS track status similar to the Play Store beta check.
+
+Secrets that will be needed (not yet configured):
+- `APPLE_CERTIFICATE_BASE64` — distribution certificate (.p12, base64)
+- `APPLE_CERTIFICATE_PASSWORD` — password for the .p12
+- `APPLE_PROVISIONING_PROFILE_BASE64` — distribution provisioning profile (.mobileprovision, base64)
+- `APP_STORE_CONNECT_API_KEY_ID` — App Store Connect API key ID
+- `APP_STORE_CONNECT_API_ISSUER_ID` — App Store Connect API issuer ID
+- `APP_STORE_CONNECT_API_KEY_BASE64` — App Store Connect API private key (.p8, base64)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,214 @@
+name: Release
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: write
+
+jobs:
+  # ─────────────────────────────────────────────────────────────
+  # 1. Tests & Lint
+  # ─────────────────────────────────────────────────────────────
+  test:
+    name: Tests & Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          cache: gradle
+
+      - name: Restore google-services.json
+        run: |
+          echo "${{ secrets.GOOGLE_SERVICES_DEV }}"  | base64 --decode > app/src/dev/google-services.json
+          echo "${{ secrets.GOOGLE_SERVICES_PROD }}" | base64 --decode > app/src/prod/google-services.json
+
+      - name: Grant gradlew permission
+        run: chmod +x gradlew
+
+      - name: Run tests
+        run: ./gradlew test --no-daemon --stacktrace
+
+      - name: Run ktlint
+        run: ./gradlew ktlintCheck --no-daemon --stacktrace
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results
+          path: '**/build/test-results/**/*.xml'
+
+  # ─────────────────────────────────────────────────────────────
+  # 2. Android — Build AAB & Upload to Play Beta
+  # ─────────────────────────────────────────────────────────────
+  android:
+    name: Android — Play Beta
+    needs: test
+    runs-on: ubuntu-latest
+    outputs:
+      version_name: ${{ steps.version.outputs.version_name }}
+      version_code: ${{ steps.version.outputs.version_code }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          cache: gradle
+
+      - name: Restore secrets
+        run: |
+          echo "${{ secrets.GOOGLE_SERVICES_PROD }}" | base64 --decode > app/src/prod/google-services.json
+          echo "${{ secrets.KEYSTORE_JKS }}"         | base64 --decode > ${{ github.workspace }}/teamflow.jks
+
+      - name: Extract version
+        id: version
+        run: |
+          VERSION_NAME=$(grep 'versionName' app/build.gradle.kts | grep -oP '"[^"]+"' | tr -d '"')
+          VERSION_CODE=$(grep 'versionCode' app/build.gradle.kts | grep -oP '\d+')
+          echo "version_name=$VERSION_NAME" >> $GITHUB_OUTPUT
+          echo "version_code=$VERSION_CODE" >> $GITHUB_OUTPUT
+
+      - name: Grant gradlew permission
+        run: chmod +x gradlew
+
+      - name: Build signed AAB
+        env:
+          KEYSTORE_PATH: ${{ github.workspace }}/teamflow.jks
+          KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
+          KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
+          KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
+        run: ./gradlew :app:bundleProdRelease --no-daemon
+
+      - name: Upload AAB artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: TeamFlowManager-${{ steps.version.outputs.version_name }}.aab
+          path: app/build/outputs/bundle/prodRelease/app-prod-release.aab
+          retention-days: 30
+
+      - name: Upload to Google Play Beta
+        uses: r0adkll/upload-google-play@v1
+        with:
+          serviceAccountJsonPlainText: ${{ secrets.GOOGLE_PLAY_SERVICE_ACCOUNT_JSON }}
+          packageName: com.jesuslcorominas.teamflowmanager
+          releaseFiles: app/build/outputs/bundle/prodRelease/app-prod-release.aab
+          track: beta
+          status: completed
+          whatsNewDirectory: distribution/whatsnew
+
+  # ─────────────────────────────────────────────────────────────
+  # 3. iOS — Build IPA & attach as artifact
+  # ─────────────────────────────────────────────────────────────
+  ios:
+    name: iOS — Build IPA
+    needs: test
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Restore GoogleService-Info plists
+        run: |
+          echo "${{ secrets.GOOGLE_SERVICE_INFO_DEV }}"  | base64 --decode > iosApp/iosApp/GoogleService-Info.plist
+          echo "${{ secrets.GOOGLE_SERVICE_INFO_PROD }}" | base64 --decode > iosApp/iosApp/GoogleService-Info-Prod.plist
+
+      - name: Select Xcode version
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: latest-stable
+
+      - name: Install CocoaPods dependencies
+        working-directory: iosApp
+        run: pod install
+
+      - name: Import Distribution Certificate
+        env:
+          CERTIFICATE_BASE64: ${{ secrets.APPLE_CERTIFICATE_BASE64 }}
+          CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+        run: |
+          KEYCHAIN_PATH=$RUNNER_TEMP/build.keychain
+          KEYCHAIN_PASS=$(openssl rand -base64 32)
+          security create-keychain -p "$KEYCHAIN_PASS" "$KEYCHAIN_PATH"
+          security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
+          security unlock-keychain -p "$KEYCHAIN_PASS" "$KEYCHAIN_PATH"
+          echo "$CERTIFICATE_BASE64" | base64 --decode > $RUNNER_TEMP/certificate.p12
+          security import $RUNNER_TEMP/certificate.p12 -P "$CERTIFICATE_PASSWORD" \
+            -A -t cert -f pkcs12 -k "$KEYCHAIN_PATH"
+          security list-keychain -d user -s "$KEYCHAIN_PATH"
+
+      - name: Install Provisioning Profile
+        env:
+          PROVISIONING_PROFILE_BASE64: ${{ secrets.APPLE_PROVISIONING_PROFILE_BASE64 }}
+        run: |
+          PP_PATH=$RUNNER_TEMP/profile.mobileprovision
+          echo "$PROVISIONING_PROFILE_BASE64" | base64 --decode > "$PP_PATH"
+          mkdir -p ~/Library/MobileDevice/Provisioning\ Profiles
+          cp "$PP_PATH" ~/Library/MobileDevice/Provisioning\ Profiles/
+
+      - name: Archive
+        run: |
+          xcodebuild archive \
+            -workspace iosApp/iosApp.xcworkspace \
+            -scheme iosApp \
+            -configuration Release \
+            -archivePath $RUNNER_TEMP/iosApp.xcarchive \
+            CODE_SIGN_STYLE=Manual \
+            -allowProvisioningUpdates
+
+      - name: Export IPA (ad-hoc)
+        run: |
+          cat > $RUNNER_TEMP/ExportOptions.plist << 'EOF'
+          <?xml version="1.0" encoding="UTF-8"?>
+          <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+          <plist version="1.0">
+          <dict>
+            <key>method</key>
+            <string>ad-hoc</string>
+            <key>teamID</key>
+            <string>KVA2CL6TMG</string>
+            <key>compileBitcode</key>
+            <false/>
+          </dict>
+          </plist>
+          EOF
+          xcodebuild -exportArchive \
+            -archivePath $RUNNER_TEMP/iosApp.xcarchive \
+            -exportOptionsPlist $RUNNER_TEMP/ExportOptions.plist \
+            -exportPath $RUNNER_TEMP/ipa
+
+      - name: Upload IPA artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: TeamFlowManager-iOS-${{ needs.android.outputs.version_name }}.ipa
+          path: ${{ runner.temp }}/ipa/*.ipa
+          retention-days: 30
+
+  # ─────────────────────────────────────────────────────────────
+  # 4. Git tag — solo si Android e iOS han ido bien
+  # ─────────────────────────────────────────────────────────────
+  tag:
+    name: Create Git Tag
+    needs: [android, ios]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Create and push tag
+        run: |
+          VERSION="v${{ needs.android.outputs.version_name }}"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag "$VERSION"
+          git push origin "$VERSION"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,8 @@ name: Release
 
 on:
   push:
-    branches: [main]
+    tags:
+      - 'v*'
 
 permissions:
   contents: write
@@ -196,19 +197,31 @@ jobs:
           retention-days: 30
 
   # ─────────────────────────────────────────────────────────────
-  # 4. Git tag — solo si Android e iOS han ido bien
+  # 4. GitHub Release — crea la release asociada al tag
   # ─────────────────────────────────────────────────────────────
-  tag:
-    name: Create Git Tag
+  release:
+    name: Create GitHub Release
     needs: [android, ios]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 
-      - name: Create and push tag
-        run: |
-          VERSION="v${{ needs.android.outputs.version_name }}"
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git tag "$VERSION"
-          git push origin "$VERSION"
+      - name: Download AAB artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: TeamFlowManager-${{ needs.android.outputs.version_name }}.aab
+          path: artifacts/
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.ref_name }}
+          name: TeamFlow Manager ${{ needs.android.outputs.version_name }}
+          body: |
+            ## TeamFlow Manager ${{ needs.android.outputs.version_name }}
+
+            - Android AAB adjunto (subido a Play Store Beta)
+            - iOS IPA disponible en los artefactos del workflow
+          files: artifacts/*.aab
+          draft: false
+          prerelease: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,11 +2,19 @@ name: Release
 
 on:
   push:
-    tags:
-      - 'v*'
+    branches:
+      - 'release/**'
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
+      - '.claude/**'
+      - 'distribution/whatsnew/**'
 
 permissions:
   contents: write
+
+env:
+  PACKAGE_NAME: com.jesuslcorominas.teamflowmanager
 
 jobs:
   # ─────────────────────────────────────────────────────────────
@@ -46,15 +54,73 @@ jobs:
           path: '**/build/test-results/**/*.xml'
 
   # ─────────────────────────────────────────────────────────────
-  # 2. Android — Build AAB & Upload to Play Beta
+  # 2. Validate versionCode not already published
   # ─────────────────────────────────────────────────────────────
-  android:
-    name: Android — Play Beta
+  validate-version:
+    name: Validate versionCode
     needs: test
     runs-on: ubuntu-latest
     outputs:
       version_name: ${{ steps.version.outputs.version_name }}
       version_code: ${{ steps.version.outputs.version_code }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Extract version
+        id: version
+        run: |
+          VERSION_CODE=$(grep 'versionCode' app/build.gradle.kts | grep -oP '\d+')
+          VERSION_NAME=$(grep 'versionName' app/build.gradle.kts | grep -oP '"[^"]+"' | tr -d '"')
+          echo "version_code=$VERSION_CODE" >> $GITHUB_OUTPUT
+          echo "version_name=$VERSION_NAME" >> $GITHUB_OUTPUT
+          echo "versionCode: $VERSION_CODE  versionName: $VERSION_NAME"
+
+      - uses: google-github-actions/auth@v2
+        id: auth
+        with:
+          credentials_json: ${{ secrets.GOOGLE_PLAY_SERVICE_ACCOUNT_JSON }}
+          token_format: 'access_token'
+          access_token_scopes: 'https://www.googleapis.com/auth/androidpublisher'
+
+      - name: Check versionCode availability
+        run: |
+          VERSION_CODE="${{ steps.version.outputs.version_code }}"
+          TOKEN="${{ steps.auth.outputs.access_token }}"
+          PKG="${{ env.PACKAGE_NAME }}"
+          FOUND=false
+
+          for TRACK in internal alpha beta production; do
+            RESPONSE=$(curl -s \
+              "https://androidpublisher.googleapis.com/androidpublisher/v3/applications/$PKG/tracks/$TRACK" \
+              -H "Authorization: Bearer $TOKEN")
+            EXISTS=$(echo "$RESPONSE" | python3 -c "
+import json, sys
+try:
+    d = json.load(sys.stdin)
+    codes = [str(v) for r in d.get('releases', []) for v in r.get('versionCodes', [])]
+    print('FOUND' if '$VERSION_CODE' in codes else 'OK')
+except:
+    print('OK')
+")
+            if [ "$EXISTS" = "FOUND" ]; then
+              echo "❌ versionCode $VERSION_CODE already exists in track '$TRACK'."
+              echo "   The pre-push hook should have bumped it. Run: bash scripts/install-hooks.sh"
+              FOUND=true
+            fi
+          done
+
+          if [ "$FOUND" = true ]; then
+            exit 1
+          fi
+          echo "✅ versionCode $VERSION_CODE is available in all tracks"
+
+  # ─────────────────────────────────────────────────────────────
+  # 3. Android — Build AAB & Upload to Play Beta
+  # ─────────────────────────────────────────────────────────────
+  android:
+    name: Android — Play Beta
+    needs: validate-version
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 
@@ -68,14 +134,6 @@ jobs:
         run: |
           echo "${{ secrets.GOOGLE_SERVICES_PROD }}" | base64 --decode > app/src/prod/google-services.json
           echo "${{ secrets.KEYSTORE_JKS }}"         | base64 --decode > ${{ github.workspace }}/teamflow.jks
-
-      - name: Extract version
-        id: version
-        run: |
-          VERSION_NAME=$(grep 'versionName' app/build.gradle.kts | grep -oP '"[^"]+"' | tr -d '"')
-          VERSION_CODE=$(grep 'versionCode' app/build.gradle.kts | grep -oP '\d+')
-          echo "version_name=$VERSION_NAME" >> $GITHUB_OUTPUT
-          echo "version_code=$VERSION_CODE" >> $GITHUB_OUTPUT
 
       - name: Grant gradlew permission
         run: chmod +x gradlew
@@ -91,26 +149,67 @@ jobs:
       - name: Upload AAB artifact
         uses: actions/upload-artifact@v4
         with:
-          name: TeamFlowManager-${{ steps.version.outputs.version_name }}.aab
+          name: TeamFlowManager-${{ needs.validate-version.outputs.version_name }}.aab
           path: app/build/outputs/bundle/prodRelease/app-prod-release.aab
           retention-days: 30
+
+      - uses: google-github-actions/auth@v2
+        id: auth
+        with:
+          credentials_json: ${{ secrets.GOOGLE_PLAY_SERVICE_ACCOUNT_JSON }}
+          token_format: 'access_token'
+          access_token_scopes: 'https://www.googleapis.com/auth/androidpublisher'
+
+      - name: Clean old beta releases
+        run: |
+          TOKEN="${{ steps.auth.outputs.access_token }}"
+          PKG="${{ env.PACKAGE_NAME }}"
+
+          # Create edit
+          EDIT_RESPONSE=$(curl -s -X POST \
+            "https://androidpublisher.googleapis.com/androidpublisher/v3/applications/$PKG/edits" \
+            -H "Authorization: Bearer $TOKEN" \
+            -H "Content-Type: application/json" \
+            -d '{}')
+          EDIT_ID=$(echo "$EDIT_RESPONSE" | python3 -c "import json,sys; print(json.load(sys.stdin).get('id',''))")
+
+          if [ -z "$EDIT_ID" ]; then
+            echo "⚠️ Could not create edit for cleanup — skipping"
+            exit 0
+          fi
+
+          # Clear beta track
+          curl -s -X PUT \
+            "https://androidpublisher.googleapis.com/androidpublisher/v3/applications/$PKG/edits/$EDIT_ID/tracks/beta" \
+            -H "Authorization: Bearer $TOKEN" \
+            -H "Content-Type: application/json" \
+            -d '{"track":"beta","releases":[]}'
+
+          # Commit edit
+          curl -s -X POST \
+            "https://androidpublisher.googleapis.com/androidpublisher/v3/applications/$PKG/edits/$EDIT_ID:commit" \
+            -H "Authorization: Bearer $TOKEN" \
+            -H "Content-Type: application/json" \
+            -d '{}'
+
+          echo "✅ Old beta releases cleared"
 
       - name: Upload to Google Play Beta
         uses: r0adkll/upload-google-play@v1
         with:
           serviceAccountJsonPlainText: ${{ secrets.GOOGLE_PLAY_SERVICE_ACCOUNT_JSON }}
-          packageName: com.jesuslcorominas.teamflowmanager
+          packageName: ${{ env.PACKAGE_NAME }}
           releaseFiles: app/build/outputs/bundle/prodRelease/app-prod-release.aab
           track: beta
           status: completed
           whatsNewDirectory: distribution/whatsnew
 
   # ─────────────────────────────────────────────────────────────
-  # 3. iOS — Build IPA & attach as artifact
+  # 4. iOS — Build IPA & attach as artifact
   # ─────────────────────────────────────────────────────────────
   ios:
     name: iOS — Build IPA
-    needs: test
+    needs: validate-version
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4
@@ -192,16 +291,16 @@ jobs:
       - name: Upload IPA artifact
         uses: actions/upload-artifact@v4
         with:
-          name: TeamFlowManager-iOS-${{ needs.android.outputs.version_name }}.ipa
+          name: TeamFlowManager-iOS-${{ needs.validate-version.outputs.version_name }}.ipa
           path: ${{ runner.temp }}/ipa/*.ipa
           retention-days: 30
 
   # ─────────────────────────────────────────────────────────────
-  # 4. GitHub Release — crea la release asociada al tag
+  # 5. GitHub Release
   # ─────────────────────────────────────────────────────────────
-  release:
+  github-release:
     name: Create GitHub Release
-    needs: [android, ios]
+    needs: [android, ios, validate-version]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -209,19 +308,19 @@ jobs:
       - name: Download AAB artifact
         uses: actions/download-artifact@v4
         with:
-          name: TeamFlowManager-${{ needs.android.outputs.version_name }}.aab
+          name: TeamFlowManager-${{ needs.validate-version.outputs.version_name }}.aab
           path: artifacts/
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ github.ref_name }}
-          name: TeamFlow Manager ${{ needs.android.outputs.version_name }}
+          name: TeamFlow Manager ${{ needs.validate-version.outputs.version_name }}
           body: |
-            ## TeamFlow Manager ${{ needs.android.outputs.version_name }}
+            ## TeamFlow Manager ${{ needs.validate-version.outputs.version_name }}
 
-            - Android AAB adjunto (subido a Play Store Beta)
-            - iOS IPA disponible en los artefactos del workflow
+            - Android: subido a Play Store Beta — promueve manualmente a producción desde Play Console
+            - iOS: IPA disponible en los artefactos del workflow (30 días)
           files: artifacts/*.aab
           draft: false
-          prerelease: false
+          prerelease: true

--- a/.github/workflows/sync-main-to-develop.yml
+++ b/.github/workflows/sync-main-to-develop.yml
@@ -1,0 +1,53 @@
+name: Sync main → develop
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  sync:
+    name: Open PR main → develop
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check if main is ahead of develop
+        id: check
+        run: |
+          git fetch origin develop
+          AHEAD=$(git rev-list origin/develop..origin/main --count)
+          echo "ahead=$AHEAD" >> $GITHUB_OUTPUT
+
+      - name: Create PR main → develop
+        if: steps.check.outputs.ahead != '0'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Check if PR already exists
+          EXISTING=$(gh pr list --base develop --head main --state open --json number --jq '.[0].number')
+          if [ -n "$EXISTING" ]; then
+            echo "PR #$EXISTING already exists — skipping"
+            exit 0
+          fi
+
+          gh pr create \
+            --base develop \
+            --head main \
+            --title "chore: sync main → develop" \
+            --body "$(cat <<'EOF'
+## Auto-sync
+
+Este PR fue creado automáticamente al hacer merge a \`main\`.
+
+Sincroniza los cambios de producción de vuelta a \`develop\` para mantener las ramas alineadas.
+
+> Mergea este PR cuando sea conveniente — no hay urgencia.
+EOF
+)"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,6 +117,10 @@ Min SDK: 29. Target SDK: 36. Kotlin: 2.1.0. Java: 17.
 
 Antes de ejecutar cualquier tarea, consulta `.claude/SKILLS.md`. Si alguna skill encaja con lo que se pide, úsala siguiendo exactamente las instrucciones del fichero de skill correspondiente en `.claude/commands/`.
 
+# Agents
+
+Antes de ejecutar cualquier tarea técnica compleja (implementar código, revisar una PR, crear tests, escribir una tarea de GitHub), consulta `.claude/AGENTS.md`. Si algún agente encaja con lo que se pide, delega en él siguiendo exactamente su definición en `.claude/agents/`.
+
 # Claude Agent Rules
 
 - You have full autonomy to create, modify, and delete files in the project.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,6 +113,10 @@ Min SDK: 29. Target SDK: 36. Kotlin: 2.1.0. Java: 17.
 ## Documentation
 - Add md files with detailed explanations of complex features (e.g., Match state management, invitation flow) in the `docs/` directory.
 
+# Skills
+
+Antes de ejecutar cualquier tarea, consulta `.claude/SKILLS.md`. Si alguna skill encaja con lo que se pide, úsala siguiendo exactamente las instrucciones del fichero de skill correspondiente en `.claude/commands/`.
+
 # Claude Agent Rules
 
 - You have full autonomy to create, modify, and delete files in the project.

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -23,10 +23,20 @@ android {
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 
+    signingConfigs {
+        create("release") {
+            storeFile = file(System.getenv("KEYSTORE_PATH") ?: "${System.getProperty("user.home")}/desarrollo/documents/teamflow/teamflow.jks")
+            storePassword = System.getenv("KEYSTORE_PASSWORD") ?: ""
+            keyAlias = System.getenv("KEY_ALIAS") ?: ""
+            keyPassword = System.getenv("KEY_PASSWORD") ?: ""
+        }
+    }
+
     buildTypes {
         release {
             isMinifyEnabled = true
             isShrinkResources = true
+            signingConfig = signingConfigs.getByName("release")
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules.pro",

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -17,8 +17,8 @@ android {
         applicationId = "com.jesuslcorominas.teamflowmanager"
         minSdk = 29
         targetSdk = 36
-        versionCode = 7
-        versionName = "0.2.2"
+        versionCode = 8
+        versionName = "0.3.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/distribution/whatsnew/whatsnew-es-ES
+++ b/distribution/whatsnew/whatsnew-es-ES
@@ -1,0 +1,1 @@
+Mejoras de estabilidad y corrección de errores.

--- a/iosApp/iosApp.xcodeproj/project.pbxproj
+++ b/iosApp/iosApp.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		AA000000000000000000022A /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = AA000000000000000000012A /* Assets.xcassets */; };
 		AA000000000000000000023A /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = AA000000000000000000014A /* Preview Assets.xcassets */; };
 		AA000000000000000000024A /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = AA000000000000000000016A /* GoogleService-Info.plist */; };
+		AA000000000000000000025A /* GoogleService-Info-Prod.plist in Resources */ = {isa = PBXBuildFile; fileRef = AA000000000000000000018A /* GoogleService-Info-Prod.plist */; };
 		AA000000000000000000026A /* GoogleSignInHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA000000000000000000017A /* GoogleSignInHandler.swift */; };
 		CA5521B7758F5F55B1EF0F32 /* Pods_iosApp.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 22721E3F55F5E1B35B6A785A /* Pods_iosApp.framework */; };
 /* End PBXBuildFile section */
@@ -27,6 +28,7 @@
 		AA000000000000000000015A /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		AA000000000000000000016A /* GoogleService-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		AA000000000000000000017A /* GoogleSignInHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoogleSignInHandler.swift; sourceTree = "<group>"; };
+		AA000000000000000000018A /* GoogleService-Info-Prod.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "GoogleService-Info-Prod.plist"; sourceTree = "<group>"; };
 		E54ABB1FDFCE4D1BB1C1547A /* Pods-iosApp.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-iosApp.debug.xcconfig"; path = "Target Support Files/Pods-iosApp/Pods-iosApp.debug.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -57,6 +59,7 @@
 			children = (
 				AA000000000000000000015A /* Info.plist */,
 				AA000000000000000000016A /* GoogleService-Info.plist */,
+				AA000000000000000000018A /* GoogleService-Info-Prod.plist */,
 				AA000000000000000000010A /* iOSApp.swift */,
 				AA000000000000000000011A /* ContentView.swift */,
 				AA000000000000000000017A /* GoogleSignInHandler.swift */,
@@ -164,6 +167,7 @@
 				AA000000000000000000023A /* Preview Assets.xcassets in Resources */,
 				AA000000000000000000022A /* Assets.xcassets in Resources */,
 				AA000000000000000000024A /* GoogleService-Info.plist in Resources */,
+				AA000000000000000000025A /* GoogleService-Info-Prod.plist in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/iosApp/iosApp.xcodeproj/project.pbxproj
+++ b/iosApp/iosApp.xcodeproj/project.pbxproj
@@ -277,7 +277,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 8;
 				DEVELOPMENT_TEAM = KVA2CL6TMG;
 				ENABLE_PREVIEWS = YES;
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
@@ -293,7 +293,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = 0.3.0;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-framework",
@@ -314,7 +314,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 8;
 				DEVELOPMENT_TEAM = KVA2CL6TMG;
 				ENABLE_PREVIEWS = YES;
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
@@ -330,7 +330,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = 0.3.0;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-framework",

--- a/iosApp/iosApp/iOSApp.swift
+++ b/iosApp/iosApp/iOSApp.swift
@@ -6,9 +6,17 @@ import GoogleSignIn
 @main
 struct iOSApp: App {
     init() {
+        #if DEBUG
         FirebaseApp.configure()
-        // KMP-17: configure GIDSignIn with the CLIENT_ID from GoogleService-Info.plist
-        // (loaded by FirebaseApp.configure() — no need to read the plist again)
+        #else
+        if let path = Bundle.main.path(forResource: "GoogleService-Info-Prod", ofType: "plist"),
+           let options = FirebaseOptions(contentsOfFile: path) {
+            FirebaseApp.configure(options: options)
+        } else {
+            FirebaseApp.configure()
+        }
+        #endif
+        // KMP-17: configure GIDSignIn with the CLIENT_ID from the loaded GoogleService-Info plist
         if let clientID = FirebaseApp.app()?.options.clientID {
             GIDSignIn.sharedInstance.configuration = GIDConfiguration(clientID: clientID)
         }

--- a/scripts/hooks/pre-push
+++ b/scripts/hooks/pre-push
@@ -1,0 +1,53 @@
+#!/bin/bash
+# Pre-push hook: auto-bumps versionCode on release/* branches.
+# Install with: bash scripts/install-hooks.sh
+
+BRANCH=$(git symbolic-ref --short HEAD 2>/dev/null)
+
+# Only run on release/* branches
+if [[ ! "$BRANCH" =~ ^release/ ]]; then
+  exit 0
+fi
+
+# Skip if last commit was already a version bump (avoid double-bump)
+LAST_MSG=$(git log -1 --pretty=%B)
+if [[ "$LAST_MSG" == *"[skip-version-bump]"* ]]; then
+  exit 0
+fi
+
+# Extract versionName from branch name (release/0.3.0 → 0.3.0)
+VERSION_NAME="${BRANCH#release/}"
+
+# Validate semver format
+if [[ ! "$VERSION_NAME" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  echo "⚠️  Branch '$BRANCH' doesn't match release/X.Y.Z — skipping version bump"
+  exit 0
+fi
+
+# Read current versionCode
+CURRENT_CODE=$(grep 'versionCode' app/build.gradle.kts | grep -oE '[0-9]+' | head -1)
+if [ -z "$CURRENT_CODE" ]; then
+  echo "❌ Could not read versionCode from app/build.gradle.kts"
+  exit 1
+fi
+NEW_CODE=$((CURRENT_CODE + 1))
+
+echo "🔢 Bumping versionCode $CURRENT_CODE → $NEW_CODE (v$VERSION_NAME)"
+
+# Update Android
+sed -i '' "s/versionCode = $CURRENT_CODE/versionCode = $NEW_CODE/" app/build.gradle.kts
+sed -i '' "s/versionName = \"[^\"]*\"/versionName = \"$VERSION_NAME\"/" app/build.gradle.kts
+
+# Update iOS
+sed -i '' \
+  "s/CURRENT_PROJECT_VERSION = [0-9]*;/CURRENT_PROJECT_VERSION = $NEW_CODE;/g" \
+  iosApp/iosApp.xcodeproj/project.pbxproj
+sed -i '' \
+  "s/MARKETING_VERSION = [^;]*;/MARKETING_VERSION = $VERSION_NAME;/g" \
+  iosApp/iosApp.xcodeproj/project.pbxproj
+
+# Commit the bump
+git add app/build.gradle.kts iosApp/iosApp.xcodeproj/project.pbxproj
+git commit -m "chore: bump version to $VERSION_NAME (build $NEW_CODE) [skip-version-bump]"
+
+echo "✅ Version bumped and committed — pushing v$VERSION_NAME (build $NEW_CODE)"

--- a/scripts/install-hooks.sh
+++ b/scripts/install-hooks.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# Installs git hooks for this project.
+# Run once after cloning: bash scripts/install-hooks.sh
+
+HOOKS_DIR="$(git rev-parse --show-toplevel)/.git/hooks"
+SCRIPTS_DIR="$(git rev-parse --show-toplevel)/scripts/hooks"
+
+echo "Installing git hooks..."
+
+cp "$SCRIPTS_DIR/pre-push" "$HOOKS_DIR/pre-push"
+chmod +x "$HOOKS_DIR/pre-push"
+
+echo "✅ pre-push hook installed"
+echo "   Pushes to release/* branches will auto-bump versionCode."


### PR DESCRIPTION
## Resumen

Incorpora a \`develop\` todos los cambios de infraestructura acumulados en \`migration/kmp-migration\`:

### CI/CD
- Workflow \`release.yml\`: pipeline completo Android + iOS disparado en \`release/*\`
- Pre-push hook: bump automático de versionCode en ramas release
- Workflow \`sync-main-to-develop.yml\`: PR automático al hacer merge a main
- Script \`scripts/install-hooks.sh\`

### Claude agents & skills
- \`.claude/AGENTS.md\`: índice de agentes con regla de consulta
- \`.claude/SKILLS.md\`: índice de skills con regla de consulta
- \`.claude/commands/publish.md\`: skill \`/publish\` con guía de release + nota iOS futura
- Agentes actualizados: de enfoque migración KMP → proyecto KMP-nativo
- Reglas añadidas en \`CLAUDE.md\` para consultar índices antes de cualquier tarea

### Config
- \`app/build.gradle.kts\`: signing config, versionCode 8, versionName 0.3.0
- \`distribution/whatsnew/whatsnew-es-ES\`
- \`.gitignore\`: .kotlin/, .firebase/, node_modules/, .DS_Store, xcuserdata

### iOS
- \`iosApp/iOSApp.swift\`: carga GoogleService-Info según flavor (#if DEBUG)
- \`project.pbxproj\`: GoogleService-Info-Prod.plist añadido como resource

## Test plan
- [ ] Verificar que \`develop\` tiene todos los ficheros de \`.claude/\` correctos tras el merge
- [ ] Crear rama \`release/0.3.0\` desde develop y hacer push para probar el hook + CI