### PR TITLE
fix(ui): fix system nav bar overlapping bottom bar on Android

### DIFF
--- a/app/src/main/java/com/jesuslcorominas/teamflowmanager/ui/components/bottomnav/BottomNavItem.kt
+++ b/app/src/main/java/com/jesuslcorominas/teamflowmanager/ui/components/bottomnav/BottomNavItem.kt
@@ -31,7 +31,7 @@ fun BottomNavItem(
         contentAlignment = Alignment.Center,
     ) {
         val animatedHeight by animateDpAsState(
-            targetValue = if (isSelected) 48.dp else 40.dp,
+            targetValue = if (isSelected) 56.dp else 48.dp,
             label = "",
         )
         val animatedAlpha by animateFloatAsState(

--- a/app/src/main/java/com/jesuslcorominas/teamflowmanager/ui/navigation/BottomNavigationBar.kt
+++ b/app/src/main/java/com/jesuslcorominas/teamflowmanager/ui/navigation/BottomNavigationBar.kt
@@ -1,6 +1,7 @@
 package com.jesuslcorominas.teamflowmanager.ui.navigation
 
 import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.BarChart
@@ -14,6 +15,7 @@ import androidx.compose.material3.NavigationBarItemDefaults
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.unit.dp
@@ -55,7 +57,11 @@ fun BottomNavigationBar(
         shadowElevation = 8.dp,
         color = BackgroundContrast,
     ) {
-        NavigationBar(containerColor = Color.Transparent, windowInsets = WindowInsets(0)) {
+        NavigationBar(
+            containerColor = Color.Transparent,
+            windowInsets = WindowInsets(0),
+            modifier = Modifier.navigationBarsPadding(),
+        ) {
             items.forEach { route ->
                 val icon: ImageVector? = route.toIcon()
                 val labelRes: Int? = route.toStringRes()


### PR DESCRIPTION
## Problema

La barra de navegación del sistema Android (botones o gesto) se solapaba con la bottom bar de la app en dispositivos con `enableEdgeToEdge()` activo.

Además, la bottom bar había quedado con poca altura tras la migración KMP.

## Causa

`navigationBarsPadding()` aplicado en el `Surface` lo reducía hacia arriba, dejando espacio transparente (blanco) entre la barra y el borde de la pantalla.

## Solución

Mover `navigationBarsPadding()` del `Surface` al `NavigationBar` interior. Así el fondo oscuro del `Surface` llega hasta el borde de pantalla en todos los dispositivos, mientras los iconos quedan posicionados por encima del área del sistema.

| Dispositivo | Comportamiento |
|---|---|
| Gesture nav (Pixel 7 Pro, etc.) | Fondo oscuro hasta el borde, iconos sobre la píldora de gesto |
| 3-button nav | Fondo oscuro detrás de los botones del sistema, iconos por encima |
| Sin navbar | `navigationBarsPadding()` = 0dp, sin efecto |

## Cambios

- `BottomNavigationBar.kt` — mueve `navigationBarsPadding()` de `Surface` a `NavigationBar`
- `BottomNavItem.kt` — aumenta altura de 40/48dp a 48/56dp para acercarse al estándar Material3 (~80dp total)