### PR TITLE
feat(c3): pending team assignment screen (#312)

### DIFF
--- a/app/src/main/java/com/jesuslcorominas/teamflowmanager/ui/club/PendingTeamAssignmentScreen.kt
+++ b/app/src/main/java/com/jesuslcorominas/teamflowmanager/ui/club/PendingTeamAssignmentScreen.kt
@@ -1,0 +1,66 @@
+package com.jesuslcorominas.teamflowmanager.ui.club
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import com.jesuslcorominas.teamflowmanager.R
+import com.jesuslcorominas.teamflowmanager.viewmodel.PendingTeamAssignmentViewModel
+import org.koin.androidx.compose.koinViewModel
+
+@Composable
+fun PendingTeamAssignmentScreen(
+    onTeamAssigned: () -> Unit,
+    onSignOut: () -> Unit,
+    viewModel: PendingTeamAssignmentViewModel = koinViewModel(),
+) {
+    val uiState by viewModel.uiState.collectAsState()
+
+    LaunchedEffect(uiState) {
+        when (uiState) {
+            PendingTeamAssignmentViewModel.UiState.TeamAssigned -> onTeamAssigned()
+            PendingTeamAssignmentViewModel.UiState.SignedOut -> onSignOut()
+            PendingTeamAssignmentViewModel.UiState.Waiting -> Unit
+        }
+    }
+
+    Column(
+        modifier =
+            Modifier
+                .fillMaxSize()
+                .padding(32.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center,
+    ) {
+        Text(
+            text = stringResource(R.string.pending_team_title),
+            style = MaterialTheme.typography.headlineMedium,
+            textAlign = TextAlign.Center,
+        )
+        Spacer(modifier = Modifier.height(16.dp))
+        Text(
+            text = stringResource(R.string.pending_team_message),
+            style = MaterialTheme.typography.bodyLarge,
+            textAlign = TextAlign.Center,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        Spacer(modifier = Modifier.height(32.dp))
+        Button(onClick = viewModel::signOut) {
+            Text(stringResource(R.string.pending_team_sign_out))
+        }
+    }
+}

--- a/app/src/main/java/com/jesuslcorominas/teamflowmanager/ui/navigation/Navigation.kt
+++ b/app/src/main/java/com/jesuslcorominas/teamflowmanager/ui/navigation/Navigation.kt
@@ -22,6 +22,7 @@ import com.jesuslcorominas.teamflowmanager.ui.club.ClubSelectionScreen
 import com.jesuslcorominas.teamflowmanager.ui.club.ClubSettingsScreen
 import com.jesuslcorominas.teamflowmanager.ui.club.CreateClubScreen
 import com.jesuslcorominas.teamflowmanager.ui.club.JoinClubScreen
+import com.jesuslcorominas.teamflowmanager.ui.club.PendingTeamAssignmentScreen
 import com.jesuslcorominas.teamflowmanager.ui.club.PresidentTeamDetailScreen
 import com.jesuslcorominas.teamflowmanager.ui.invitation.AcceptTeamInvitationScreen
 import com.jesuslcorominas.teamflowmanager.ui.login.LoginScreen
@@ -69,6 +70,11 @@ fun Navigation(
                 },
                 onNavigateToCreateTeam = {
                     navController.navigate(Route.Team.createRoute(Route.Team.MODE_CREATE)) {
+                        popUpTo(Route.Splash.createRoute()) { inclusive = true }
+                    }
+                },
+                onNavigateToAwaitTeam = {
+                    navController.navigate(Route.PendingTeamAssignment.createRoute()) {
                         popUpTo(Route.Splash.createRoute()) { inclusive = true }
                     }
                 },
@@ -313,6 +319,28 @@ fun Navigation(
         }
 
         composable(
+            route = Route.PendingTeamAssignment.createRoute(),
+            // Instant transitions: no topBar, so scaffold change must be atomic.
+            enterTransition = { EnterTransition.None },
+            exitTransition = { ExitTransition.None },
+            popEnterTransition = { EnterTransition.None },
+            popExitTransition = { ExitTransition.None },
+        ) {
+            PendingTeamAssignmentScreen(
+                onTeamAssigned = {
+                    navController.navigate(Route.Matches.createRoute()) {
+                        popUpTo(0) { inclusive = true }
+                    }
+                },
+                onSignOut = {
+                    navController.navigate(Route.Login.createRoute()) {
+                        popUpTo(0) { inclusive = true }
+                    }
+                },
+            )
+        }
+
+        composable(
             route = Route.AcceptTeamInvitation.FULL_ROUTE,
             arguments =
                 listOf(
@@ -373,6 +401,7 @@ fun Navigation(
             Route.Migration -> activity?.finish()
             Route.ClubSelection -> activity?.finish()
             Route.TeamList -> activity?.finish()
+            Route.PendingTeamAssignment -> activity?.finish()
             Route.CreateClub ->
                 navController.navigate(Route.ClubSelection.createRoute()) {
                     popUpTo(Route.CreateClub.createRoute()) { inclusive = true }

--- a/app/src/main/java/com/jesuslcorominas/teamflowmanager/ui/navigation/Route.kt
+++ b/app/src/main/java/com/jesuslcorominas/teamflowmanager/ui/navigation/Route.kt
@@ -32,6 +32,7 @@ sealed class Route(
                 Settings,
                 AcceptTeamInvitation,
                 ClubSettings,
+                PendingTeamAssignment,
             )
         }
 
@@ -183,4 +184,6 @@ sealed class Route(
 
         fun createRoute(teamId: String): String = "$PATH?$ARG_TEAM_ID=$teamId"
     }
+
+    data object PendingTeamAssignment : Route(path = "pending_team_assignment", showTopBar = false)
 }

--- a/app/src/main/java/com/jesuslcorominas/teamflowmanager/ui/splash/SplashScreen.kt
+++ b/app/src/main/java/com/jesuslcorominas/teamflowmanager/ui/splash/SplashScreen.kt
@@ -17,6 +17,7 @@ fun SplashScreen(
     onNavigateToLogin: () -> Unit,
     onNavigateToClubSelection: () -> Unit,
     onNavigateToCreateTeam: () -> Unit,
+    onNavigateToAwaitTeam: () -> Unit,
     onNavigateToTeamList: () -> Unit,
     onNavigateToMatches: () -> Unit,
 ) {
@@ -34,7 +35,7 @@ fun SplashScreen(
             is UiState.NotAuthenticated -> onNavigateToLogin()
             is UiState.LocalDataNeedsAuth -> onNavigateToLogin()
             is UiState.NoClub -> onNavigateToClubSelection()
-            is UiState.NoTeam -> onNavigateToCreateTeam()
+            is UiState.NoTeam -> onNavigateToAwaitTeam()
             is UiState.ClubPresident -> onNavigateToTeamList()
             is UiState.TeamExists -> onNavigateToMatches()
             is UiState.Loading -> {

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -358,4 +358,9 @@
     <string name="president_team_stats_goals_conceded">Goles en contra</string>
     <string name="president_team_stats_squad_size">Tamaño de la plantilla</string>
 
+    <!-- Pending Team Assignment Strings -->
+    <string name="pending_team_title">Asignación de equipo pendiente</string>
+    <string name="pending_team_message">Tu cuenta ha sido verificada. Por favor, espera a que el presidente del club te asigne a un equipo.</string>
+    <string name="pending_team_sign_out">Cerrar sesión</string>
+
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -384,4 +384,9 @@
     <string name="president_team_stats_goals_conceded">Goals conceded</string>
     <string name="president_team_stats_squad_size">Squad size</string>
 
+    <!-- Pending Team Assignment Strings -->
+    <string name="pending_team_title">Pending team assignment</string>
+    <string name="pending_team_message">Your account has been verified. Please wait until the club president assigns you to a team.</string>
+    <string name="pending_team_sign_out">Sign out</string>
+
 </resources>

--- a/di/src/iosMain/kotlin/com/jesuslcorominas/teamflowmanager/di/IosModule.kt
+++ b/di/src/iosMain/kotlin/com/jesuslcorominas/teamflowmanager/di/IosModule.kt
@@ -17,6 +17,7 @@ import com.jesuslcorominas.teamflowmanager.viewmodel.MainViewModel
 import com.jesuslcorominas.teamflowmanager.viewmodel.MatchCreationWizardViewModel
 import com.jesuslcorominas.teamflowmanager.viewmodel.MatchListViewModel
 import com.jesuslcorominas.teamflowmanager.viewmodel.MatchViewModel
+import com.jesuslcorominas.teamflowmanager.viewmodel.PendingTeamAssignmentViewModel
 import com.jesuslcorominas.teamflowmanager.viewmodel.PlayerViewModel
 import com.jesuslcorominas.teamflowmanager.viewmodel.PlayerWizardViewModel
 import com.jesuslcorominas.teamflowmanager.viewmodel.PresidentTeamDetailViewModel
@@ -259,6 +260,13 @@ val iosModule =
                 teamId = params.get(),
                 acceptTeamInvitation = get(),
                 getCurrentUser = get(),
+            )
+        }
+
+        factory {
+            PendingTeamAssignmentViewModel(
+                getTeam = get(),
+                signOut = get(),
             )
         }
     }

--- a/viewmodel/src/androidMain/kotlin/com/jesuslcorominas/teamflowmanager/viewmodel/di/ViewModelModule.kt
+++ b/viewmodel/src/androidMain/kotlin/com/jesuslcorominas/teamflowmanager/viewmodel/di/ViewModelModule.kt
@@ -12,6 +12,7 @@ import com.jesuslcorominas.teamflowmanager.viewmodel.MainViewModel
 import com.jesuslcorominas.teamflowmanager.viewmodel.MatchCreationWizardViewModel
 import com.jesuslcorominas.teamflowmanager.viewmodel.MatchListViewModel
 import com.jesuslcorominas.teamflowmanager.viewmodel.MatchViewModel
+import com.jesuslcorominas.teamflowmanager.viewmodel.PendingTeamAssignmentViewModel
 import com.jesuslcorominas.teamflowmanager.viewmodel.PlayerViewModel
 import com.jesuslcorominas.teamflowmanager.viewmodel.PlayerWizardViewModel
 import com.jesuslcorominas.teamflowmanager.viewmodel.PresidentTeamDetailViewModel
@@ -241,6 +242,13 @@ val viewModelModule =
                 teamId = params.get(),
                 acceptTeamInvitation = get(),
                 getCurrentUser = get(),
+            )
+        }
+
+        viewModel {
+            PendingTeamAssignmentViewModel(
+                getTeam = get(),
+                signOut = get(),
             )
         }
 

--- a/viewmodel/src/androidUnitTest/kotlin/com/jesuslcorominas/teamflowmanager/viewmodel/SplashViewModelTest.kt
+++ b/viewmodel/src/androidUnitTest/kotlin/com/jesuslcorominas/teamflowmanager/viewmodel/SplashViewModelTest.kt
@@ -120,7 +120,7 @@ class SplashViewModelTest {
     }
 
     @Test
-    fun `should emit NoClub when user has no team and is a club member but not President`() = runTest {
+    fun `should emit NoTeam when user is a club member but has no team assigned`() = runTest {
         val clubMember = ClubMember(
             id = 1,
             userId = "user123",
@@ -138,7 +138,7 @@ class SplashViewModelTest {
         val viewModel = createViewModel()
         advanceUntilIdle()
 
-        assertEquals(SplashViewModel.UiState.NoClub, viewModel.uiState.value)
+        assertEquals(SplashViewModel.UiState.NoTeam, viewModel.uiState.value)
     }
 
     @Test

--- a/viewmodel/src/commonMain/kotlin/com/jesuslcorominas/teamflowmanager/viewmodel/PendingTeamAssignmentViewModel.kt
+++ b/viewmodel/src/commonMain/kotlin/com/jesuslcorominas/teamflowmanager/viewmodel/PendingTeamAssignmentViewModel.kt
@@ -1,0 +1,43 @@
+package com.jesuslcorominas.teamflowmanager.viewmodel
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.jesuslcorominas.teamflowmanager.domain.usecase.GetTeamUseCase
+import com.jesuslcorominas.teamflowmanager.domain.usecase.SignOutUseCase
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+
+class PendingTeamAssignmentViewModel(
+    private val getTeam: GetTeamUseCase,
+    private val signOut: SignOutUseCase,
+) : ViewModel() {
+    sealed interface UiState {
+        data object Waiting : UiState
+
+        data object TeamAssigned : UiState
+
+        data object SignedOut : UiState
+    }
+
+    private val _uiState = MutableStateFlow<UiState>(UiState.Waiting)
+    val uiState: StateFlow<UiState> = _uiState.asStateFlow()
+
+    init {
+        viewModelScope.launch {
+            getTeam().collect { team ->
+                if (team != null) {
+                    _uiState.value = UiState.TeamAssigned
+                }
+            }
+        }
+    }
+
+    fun signOut() {
+        viewModelScope.launch {
+            runCatching { signOut.invoke() }
+            _uiState.value = UiState.SignedOut
+        }
+    }
+}

--- a/viewmodel/src/commonMain/kotlin/com/jesuslcorominas/teamflowmanager/viewmodel/SplashViewModel.kt
+++ b/viewmodel/src/commonMain/kotlin/com/jesuslcorominas/teamflowmanager/viewmodel/SplashViewModel.kt
@@ -98,7 +98,8 @@ class SplashViewModel(
                 runCatching { signOutUseCase() }
                 _uiState.value = UiState.NotAuthenticated
             } else {
-                _uiState.value = UiState.NoClub
+                // Member belongs to a club but has no team assigned yet — show waiting screen.
+                _uiState.value = UiState.NoTeam
             }
         } else {
             val clubFirestoreId = team.clubFirestoreId


### PR DESCRIPTION
## Summary

- Adds `PendingTeamAssignmentScreen` shown when an authenticated club member has not been assigned to any team yet
- Adds `PendingTeamAssignmentViewModel` — observes `GetTeamUseCase` and navigates automatically when the president assigns the user; exposes a sign-out action
- **Fixes root bug in `SplashViewModel`**: was emitting `NoClub` (→ club-selection screen) instead of `NoTeam` when `clubMember != null && team == null`, causing an infinite loop back to club selection
- Adds `Route.PendingTeamAssignment` with instant scaffold transitions (no top bar)
- Splits `SplashScreen.onNavigateToCreateTeam` (president creates a new team) from new `onNavigateToAwaitTeam` (member waits for assignment)
- Updates `SplashViewModelTest`: renames and corrects the assertion for the club-member-without-team scenario
- Adds `pending_team_*` strings in English and Spanish

## Test plan

- [ ] Sign in as a club member whose account has no team assigned → should land on the pending screen, not club-selection
- [ ] While on the pending screen, have the president assign a team → app navigates automatically to Matches
- [ ] Tap "Sign out" on the pending screen → returns to Login
- [ ] President flow (ClubPresident state) is unaffected
- [ ] All existing viewmodel unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)