### PR TITLE
feat(c3): team search by name and filter without coach (#305 #306)

### DIFF
--- a/app/src/main/java/com/jesuslcorominas/teamflowmanager/ui/components/topbar/AppTopBar.kt
+++ b/app/src/main/java/com/jesuslcorominas/teamflowmanager/ui/components/topbar/AppTopBar.kt
@@ -1,5 +1,6 @@
 package com.jesuslcorominas.teamflowmanager.ui.components.topbar
 
+import androidx.activity.compose.BackHandler
 import androidx.compose.animation.Crossfade
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
@@ -76,6 +77,11 @@ fun SearchTopBar(
     placeholder: String,
 ) {
     val searchState = LocalSearchState.current
+
+    BackHandler {
+        searchState.clear()
+        searchState.isActive = false
+    }
 
     TopAppBar(
         modifier = modifier,

--- a/app/src/main/java/com/jesuslcorominas/teamflowmanager/ui/main/MainScreen.kt
+++ b/app/src/main/java/com/jesuslcorominas/teamflowmanager/ui/main/MainScreen.kt
@@ -117,12 +117,10 @@ private fun MainScaffold(
                     title = title,
                     backHandlerController = backHandlerController,
                     searchPlaceholder =
-                        if (route is Route.Matches) {
-                            stringResource(
-                                R.string.search_match_placeholder,
-                            )
-                        } else {
-                            ""
+                        when (route) {
+                            Route.Matches -> stringResource(R.string.search_match_placeholder)
+                            Route.TeamList -> stringResource(R.string.search_team_placeholder)
+                            else -> ""
                         },
                     navController = navController,
                 )

--- a/app/src/main/java/com/jesuslcorominas/teamflowmanager/ui/navigation/Route.kt
+++ b/app/src/main/java/com/jesuslcorominas/teamflowmanager/ui/navigation/Route.kt
@@ -125,7 +125,7 @@ sealed class Route(
         showTopBar = true,
         showBottomBar = true,
         showFab = true,
-        hasSearchBar = false,
+        hasSearchBar = true,
         showSettingsButton = true,
     )
 

--- a/app/src/main/java/com/jesuslcorominas/teamflowmanager/ui/team/TeamListScreen.kt
+++ b/app/src/main/java/com/jesuslcorominas/teamflowmanager/ui/team/TeamListScreen.kt
@@ -44,6 +44,7 @@ import com.jesuslcorominas.teamflowmanager.ui.analytics.TrackScreenView
 import com.jesuslcorominas.teamflowmanager.ui.components.Loading
 import com.jesuslcorominas.teamflowmanager.ui.components.card.AppCard
 import com.jesuslcorominas.teamflowmanager.ui.main.LocalContentBottomPadding
+import com.jesuslcorominas.teamflowmanager.ui.main.search.LocalSearchState
 import com.jesuslcorominas.teamflowmanager.ui.theme.TFMSpacing
 import com.jesuslcorominas.teamflowmanager.viewmodel.TeamListViewModel
 import org.koin.androidx.compose.koinViewModel
@@ -60,8 +61,13 @@ fun TeamListScreen(
     val sharingTeamId by viewModel.sharingTeamId.collectAsState()
     val assigningCoachToTeamId by viewModel.assigningCoachToTeamId.collectAsState()
     val currentUserRole by viewModel.currentUserRole.collectAsState()
-    val showOnlyWithoutCoach by viewModel.showOnlyWithoutCoach.collectAsState()
+    val coachFilter by viewModel.coachFilter.collectAsState()
+    val searchState = LocalSearchState.current
     val context = LocalContext.current
+
+    LaunchedEffect(searchState.query) {
+        viewModel.onSearchQueryChanged(searchState.query)
+    }
 
     // Handle share event
     LaunchedEffect(shareEvent) {
@@ -89,12 +95,26 @@ fun TeamListScreen(
                 val isPresident = currentUserRole == ClubRole.PRESIDENT.roleName
                 Column(modifier = Modifier.fillMaxSize()) {
                     if (isPresident) {
-                        FilterChip(
-                            selected = showOnlyWithoutCoach,
-                            onClick = { viewModel.toggleWithoutCoachFilter() },
-                            label = { Text(stringResource(R.string.team_filter_without_coach)) },
+                        Row(
                             modifier = Modifier.padding(horizontal = TFMSpacing.spacing04, vertical = 4.dp),
-                        )
+                            horizontalArrangement = Arrangement.spacedBy(8.dp),
+                        ) {
+                            FilterChip(
+                                selected = coachFilter == TeamListViewModel.CoachFilter.ALL,
+                                onClick = { viewModel.onCoachFilterChanged(TeamListViewModel.CoachFilter.ALL) },
+                                label = { Text(stringResource(R.string.team_filter_all)) },
+                            )
+                            FilterChip(
+                                selected = coachFilter == TeamListViewModel.CoachFilter.WITH_COACH,
+                                onClick = { viewModel.onCoachFilterChanged(TeamListViewModel.CoachFilter.WITH_COACH) },
+                                label = { Text(stringResource(R.string.team_filter_with_coach)) },
+                            )
+                            FilterChip(
+                                selected = coachFilter == TeamListViewModel.CoachFilter.WITHOUT_COACH,
+                                onClick = { viewModel.onCoachFilterChanged(TeamListViewModel.CoachFilter.WITHOUT_COACH) },
+                                label = { Text(stringResource(R.string.team_filter_without_coach)) },
+                            )
+                        }
                     }
                     if (state.teams.isEmpty()) {
                         EmptyTeamsMessage(modifier = Modifier.weight(1f).fillMaxWidth())

--- a/app/src/main/java/com/jesuslcorominas/teamflowmanager/ui/team/TeamListScreen.kt
+++ b/app/src/main/java/com/jesuslcorominas/teamflowmanager/ui/team/TeamListScreen.kt
@@ -21,6 +21,7 @@ import androidx.compose.material.icons.filled.PersonAdd
 import androidx.compose.material.icons.filled.Share
 import androidx.compose.material3.Button
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.FilterChip
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -59,6 +60,7 @@ fun TeamListScreen(
     val sharingTeamId by viewModel.sharingTeamId.collectAsState()
     val assigningCoachToTeamId by viewModel.assigningCoachToTeamId.collectAsState()
     val currentUserRole by viewModel.currentUserRole.collectAsState()
+    val showOnlyWithoutCoach by viewModel.showOnlyWithoutCoach.collectAsState()
     val context = LocalContext.current
 
     // Handle share event
@@ -84,19 +86,30 @@ fun TeamListScreen(
                 Loading()
             }
             is TeamListViewModel.UiState.Success -> {
-                if (state.teams.isEmpty()) {
-                    EmptyTeamsMessage(modifier = Modifier.fillMaxSize())
-                } else {
-                    TeamsListContent(
-                        teams = state.teams,
-                        modifier = Modifier.fillMaxSize(),
-                        onTeamClick = onTeamClick,
-                        onShareTeam = { team -> viewModel.shareTeam(team) },
-                        onSelfAssignAsCoach = { team -> viewModel.selfAssignAsCoachToTeam(team) },
-                        sharingTeamId = sharingTeamId,
-                        assigningCoachToTeamId = assigningCoachToTeamId,
-                        isPresident = currentUserRole == ClubRole.PRESIDENT.roleName,
-                    )
+                val isPresident = currentUserRole == ClubRole.PRESIDENT.roleName
+                Column(modifier = Modifier.fillMaxSize()) {
+                    if (isPresident) {
+                        FilterChip(
+                            selected = showOnlyWithoutCoach,
+                            onClick = { viewModel.toggleWithoutCoachFilter() },
+                            label = { Text(stringResource(R.string.team_filter_without_coach)) },
+                            modifier = Modifier.padding(horizontal = TFMSpacing.spacing04, vertical = 4.dp),
+                        )
+                    }
+                    if (state.teams.isEmpty()) {
+                        EmptyTeamsMessage(modifier = Modifier.weight(1f).fillMaxWidth())
+                    } else {
+                        TeamsListContent(
+                            teams = state.teams,
+                            modifier = Modifier.weight(1f),
+                            onTeamClick = onTeamClick,
+                            onShareTeam = { team -> viewModel.shareTeam(team) },
+                            onSelfAssignAsCoach = { team -> viewModel.selfAssignAsCoachToTeam(team) },
+                            sharingTeamId = sharingTeamId,
+                            assigningCoachToTeamId = assigningCoachToTeamId,
+                            isPresident = isPresident,
+                        )
+                    }
                 }
             }
             is TeamListViewModel.UiState.Error -> {

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -113,6 +113,8 @@
     <string name="team_title">Equipo</string>
     <string name="team_list_title">Equipos del Club</string>
     <string name="no_teams_message">Aún no hay equipos. ¡Crea tu primer equipo!</string>
+    <string name="team_filter_all">Todos</string>
+    <string name="team_filter_with_coach">Con entrenador</string>
     <string name="team_filter_without_coach">Sin entrenador</string>
     <string name="create_team_title">Crear Equipo</string>
     <string name="team_name">Nombre del Equipo</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -113,6 +113,7 @@
     <string name="team_title">Equipo</string>
     <string name="team_list_title">Equipos del Club</string>
     <string name="no_teams_message">Aún no hay equipos. ¡Crea tu primer equipo!</string>
+    <string name="team_filter_without_coach">Sin entrenador</string>
     <string name="create_team_title">Crear Equipo</string>
     <string name="team_name">Nombre del Equipo</string>
     <string name="team_name_required">El nombre del equipo es obligatorio</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -271,6 +271,7 @@
     <string name="match_timeout">Tiempo Muerto</string>
 
     <string name="search_match_placeholder">Busca por oponente o ubicación</string>
+    <string name="search_team_placeholder">Busca equipos por nombre</string>
 
     <!-- Analysis -->
     <string name="analysis_title">Análisis</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -113,6 +113,7 @@
     <string name="team_title">Team</string>
     <string name="team_list_title">Club Teams</string>
     <string name="no_teams_message">No teams yet. Create your first team!</string>
+    <string name="team_filter_without_coach">Without coach</string>
     <string name="error_loading_teams">Unable to load teams. Please check your internet connection and try again.</string>
     <string name="no_club_membership_teams_error">You need to join or create a club first to view teams.</string>
     <string name="no_members_message">No staff members in your club yet. Invite members to join!</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -292,6 +292,7 @@
     <string name="match_timeout">Timeout</string>
 
     <string name="search_match_placeholder">Search matches by opponent or place</string>
+    <string name="search_team_placeholder">Search teams by name</string>
 
     <!-- Analysis -->
     <string name="analysis_title">Analysis</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -113,6 +113,8 @@
     <string name="team_title">Team</string>
     <string name="team_list_title">Club Teams</string>
     <string name="no_teams_message">No teams yet. Create your first team!</string>
+    <string name="team_filter_all">All</string>
+    <string name="team_filter_with_coach">With coach</string>
     <string name="team_filter_without_coach">Without coach</string>
     <string name="error_loading_teams">Unable to load teams. Please check your internet connection and try again.</string>
     <string name="no_club_membership_teams_error">You need to join or create a club first to view teams.</string>

--- a/viewmodel/src/androidUnitTest/kotlin/com/jesuslcorominas/teamflowmanager/viewmodel/TeamListViewModelTest.kt
+++ b/viewmodel/src/androidUnitTest/kotlin/com/jesuslcorominas/teamflowmanager/viewmodel/TeamListViewModelTest.kt
@@ -259,4 +259,181 @@ class TeamListViewModelTest {
         // Then
         assertEquals(TeamListViewModel.UiState.Error, viewModel.uiState.value)
     }
+
+    // region Search
+
+    @Test
+    fun `initial searchQuery should be empty`() = runTest(testDispatcher) {
+        // Given
+        every { getUserClubMembershipUseCase.invoke() } returns flowOf(null)
+
+        // When
+        val viewModel = createViewModel()
+
+        // Then
+        assertEquals("", viewModel.searchQuery.value)
+    }
+
+    @Test
+    fun `onSearchQueryChanged filters teams by name case insensitively`() = runTest(testDispatcher) {
+        // Given
+        val member = presidentMember()
+        val teamA = teamWithName("Alpha", firestoreId = "t1")
+        val teamB = teamWithName("Beta", firestoreId = "t2")
+        every { getUserClubMembershipUseCase.invoke() } returns flowOf(member)
+        every { getTeamsByClubUseCase.invoke("club_fs_1") } returns flowOf(listOf(teamA, teamB))
+        val viewModel = createViewModel()
+        advanceUntilIdle()
+
+        // When
+        viewModel.onSearchQueryChanged("alph")
+        advanceUntilIdle()
+
+        // Then
+        assertEquals(
+            TeamListViewModel.UiState.Success(listOf(teamA), member.name),
+            viewModel.uiState.value,
+        )
+    }
+
+    @Test
+    fun `onSearchQueryChanged with blank query shows all teams`() = runTest(testDispatcher) {
+        // Given
+        val member = presidentMember()
+        val teamA = teamWithName("Alpha", firestoreId = "t1")
+        val teamB = teamWithName("Beta", firestoreId = "t2")
+        every { getUserClubMembershipUseCase.invoke() } returns flowOf(member)
+        every { getTeamsByClubUseCase.invoke("club_fs_1") } returns flowOf(listOf(teamA, teamB))
+        val viewModel = createViewModel()
+        viewModel.onSearchQueryChanged("alph")
+        advanceUntilIdle()
+
+        // When
+        viewModel.onSearchQueryChanged("")
+        advanceUntilIdle()
+
+        // Then
+        assertEquals(
+            TeamListViewModel.UiState.Success(listOf(teamA, teamB), member.name),
+            viewModel.uiState.value,
+        )
+    }
+
+    // endregion
+
+    // region CoachFilter
+
+    @Test
+    fun `initial coachFilter should be ALL`() = runTest(testDispatcher) {
+        // Given
+        every { getUserClubMembershipUseCase.invoke() } returns flowOf(null)
+
+        // When
+        val viewModel = createViewModel()
+
+        // Then
+        assertEquals(TeamListViewModel.CoachFilter.ALL, viewModel.coachFilter.value)
+    }
+
+    @Test
+    fun `onCoachFilterChanged ALL shows all teams regardless of coach`() = runTest(testDispatcher) {
+        // Given
+        val member = presidentMember()
+        val withCoach = teamWithName("With Coach", firestoreId = "t1", coachId = "c1")
+        val withoutCoach = teamWithName("No Coach", firestoreId = "t2", coachId = null)
+        every { getUserClubMembershipUseCase.invoke() } returns flowOf(member)
+        every { getTeamsByClubUseCase.invoke("club_fs_1") } returns flowOf(listOf(withCoach, withoutCoach))
+        val viewModel = createViewModel()
+        advanceUntilIdle()
+
+        // When
+        viewModel.onCoachFilterChanged(TeamListViewModel.CoachFilter.ALL)
+        advanceUntilIdle()
+
+        // Then
+        val state = viewModel.uiState.value as TeamListViewModel.UiState.Success
+        assertEquals(listOf(withCoach, withoutCoach), state.teams)
+    }
+
+    @Test
+    fun `onCoachFilterChanged WITH_COACH shows only teams that have a coach`() = runTest(testDispatcher) {
+        // Given
+        val member = presidentMember()
+        val withCoach = teamWithName("With Coach", firestoreId = "t1", coachId = "c1")
+        val withoutCoach = teamWithName("No Coach", firestoreId = "t2", coachId = null)
+        every { getUserClubMembershipUseCase.invoke() } returns flowOf(member)
+        every { getTeamsByClubUseCase.invoke("club_fs_1") } returns flowOf(listOf(withCoach, withoutCoach))
+        val viewModel = createViewModel()
+        advanceUntilIdle()
+
+        // When
+        viewModel.onCoachFilterChanged(TeamListViewModel.CoachFilter.WITH_COACH)
+        advanceUntilIdle()
+
+        // Then
+        val state = viewModel.uiState.value as TeamListViewModel.UiState.Success
+        assertEquals(listOf(withCoach), state.teams)
+    }
+
+    @Test
+    fun `onCoachFilterChanged WITHOUT_COACH shows only teams without a coach`() = runTest(testDispatcher) {
+        // Given
+        val member = presidentMember()
+        val withCoach = teamWithName("With Coach", firestoreId = "t1", coachId = "c1")
+        val withoutCoach = teamWithName("No Coach", firestoreId = "t2", coachId = null)
+        every { getUserClubMembershipUseCase.invoke() } returns flowOf(member)
+        every { getTeamsByClubUseCase.invoke("club_fs_1") } returns flowOf(listOf(withCoach, withoutCoach))
+        val viewModel = createViewModel()
+        advanceUntilIdle()
+
+        // When
+        viewModel.onCoachFilterChanged(TeamListViewModel.CoachFilter.WITHOUT_COACH)
+        advanceUntilIdle()
+
+        // Then
+        val state = viewModel.uiState.value as TeamListViewModel.UiState.Success
+        assertEquals(listOf(withoutCoach), state.teams)
+    }
+
+    @Test
+    fun `search and coach filter are applied together`() = runTest(testDispatcher) {
+        // Given
+        val member = presidentMember()
+        val alphaWithCoach = teamWithName("Alpha", firestoreId = "t1", coachId = "c1")
+        val alphaNoCoach = teamWithName("Alpha B", firestoreId = "t2", coachId = null)
+        val betaNoCoach = teamWithName("Beta", firestoreId = "t3", coachId = null)
+        every { getUserClubMembershipUseCase.invoke() } returns flowOf(member)
+        every { getTeamsByClubUseCase.invoke("club_fs_1") } returns flowOf(listOf(alphaWithCoach, alphaNoCoach, betaNoCoach))
+        val viewModel = createViewModel()
+        advanceUntilIdle()
+
+        // When: search "alpha" + filter WITHOUT_COACH
+        viewModel.onSearchQueryChanged("alpha")
+        viewModel.onCoachFilterChanged(TeamListViewModel.CoachFilter.WITHOUT_COACH)
+        advanceUntilIdle()
+
+        // Then: only alphaNoCoach matches both conditions
+        val state = viewModel.uiState.value as TeamListViewModel.UiState.Success
+        assertEquals(listOf(alphaNoCoach), state.teams)
+    }
+
+    // endregion
+
+    // region helpers
+
+    private fun teamWithName(
+        name: String,
+        firestoreId: String,
+        coachId: String? = null,
+    ) = Team(
+        id = firestoreId.hashCode().toLong(),
+        name = name,
+        coachName = if (coachId != null) "Coach" else "",
+        delegateName = "",
+        teamType = TeamType.FOOTBALL_5,
+        firestoreId = firestoreId,
+        coachId = coachId,
+    )
+
+    // endregion
 }

--- a/viewmodel/src/commonMain/kotlin/com/jesuslcorominas/teamflowmanager/viewmodel/TeamListViewModel.kt
+++ b/viewmodel/src/commonMain/kotlin/com/jesuslcorominas/teamflowmanager/viewmodel/TeamListViewModel.kt
@@ -39,8 +39,10 @@ class TeamListViewModel(
     private val _searchQuery = MutableStateFlow("")
     val searchQuery: StateFlow<String> = _searchQuery.asStateFlow()
 
-    private val _showOnlyWithoutCoach = MutableStateFlow(false)
-    val showOnlyWithoutCoach: StateFlow<Boolean> = _showOnlyWithoutCoach.asStateFlow()
+    private val _coachFilter = MutableStateFlow(CoachFilter.ALL)
+    val coachFilter: StateFlow<CoachFilter> = _coachFilter.asStateFlow()
+
+    enum class CoachFilter { ALL, WITH_COACH, WITHOUT_COACH }
 
     sealed interface UiState {
         data object Loading : UiState
@@ -83,12 +85,18 @@ class TeamListViewModel(
                 combine(
                     getTeamsByClub(clubFirestoreId),
                     _searchQuery,
-                    _showOnlyWithoutCoach,
-                ) { teams, query, withoutCoach ->
+                    _coachFilter,
+                ) { teams, query, coachFilter ->
                     val filtered =
                         teams
                             .filter { query.isBlank() || it.name.contains(query, ignoreCase = true) }
-                            .filter { !withoutCoach || it.coachId == null }
+                            .filter {
+                                when (coachFilter) {
+                                    CoachFilter.ALL -> true
+                                    CoachFilter.WITH_COACH -> it.coachId != null
+                                    CoachFilter.WITHOUT_COACH -> it.coachId == null
+                                }
+                            }
                     UiState.Success(filtered, clubMember.name)
                 }.collect { state ->
                     _uiState.value = state
@@ -125,8 +133,8 @@ class TeamListViewModel(
         _searchQuery.value = query
     }
 
-    fun toggleWithoutCoachFilter() {
-        _showOnlyWithoutCoach.value = !_showOnlyWithoutCoach.value
+    fun onCoachFilterChanged(filter: CoachFilter) {
+        _coachFilter.value = filter
     }
 
     fun onShareEventConsumed() {

--- a/viewmodel/src/commonMain/kotlin/com/jesuslcorominas/teamflowmanager/viewmodel/TeamListViewModel.kt
+++ b/viewmodel/src/commonMain/kotlin/com/jesuslcorominas/teamflowmanager/viewmodel/TeamListViewModel.kt
@@ -11,6 +11,7 @@ import com.jesuslcorominas.teamflowmanager.domain.usecase.SelfAssignAsCoachUseCa
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 
@@ -34,6 +35,12 @@ class TeamListViewModel(
 
     private val _currentUserRole = MutableStateFlow<String?>(null)
     val currentUserRole: StateFlow<String?> = _currentUserRole.asStateFlow()
+
+    private val _searchQuery = MutableStateFlow("")
+    val searchQuery: StateFlow<String> = _searchQuery.asStateFlow()
+
+    private val _showOnlyWithoutCoach = MutableStateFlow(false)
+    val showOnlyWithoutCoach: StateFlow<Boolean> = _showOnlyWithoutCoach.asStateFlow()
 
     sealed interface UiState {
         data object Loading : UiState
@@ -72,9 +79,19 @@ class TeamListViewModel(
                         clubMember.roles.firstOrNull() ?: ""
                     }
 
-                // Load teams for the club
-                getTeamsByClub(clubFirestoreId).collect { teams ->
-                    _uiState.value = UiState.Success(teams, clubMember.name)
+                // Load teams for the club, applying search and filter reactively
+                combine(
+                    getTeamsByClub(clubFirestoreId),
+                    _searchQuery,
+                    _showOnlyWithoutCoach,
+                ) { teams, query, withoutCoach ->
+                    val filtered =
+                        teams
+                            .filter { query.isBlank() || it.name.contains(query, ignoreCase = true) }
+                            .filter { !withoutCoach || it.coachId == null }
+                    UiState.Success(filtered, clubMember.name)
+                }.collect { state ->
+                    _uiState.value = state
                 }
             } catch (e: Exception) {
                 _uiState.value = UiState.Error
@@ -102,6 +119,14 @@ class TeamListViewModel(
                 _sharingTeamId.value = null
             }
         }
+    }
+
+    fun onSearchQueryChanged(query: String) {
+        _searchQuery.value = query
+    }
+
+    fun toggleWithoutCoachFilter() {
+        _showOnlyWithoutCoach.value = !_showOnlyWithoutCoach.value
     }
 
     fun onShareEventConsumed() {


### PR DESCRIPTION
## Summary

- Search teams by name (reactive, client-side via top bar search)
- Filter chip "Without coach" visible only to Presidents

## Changes

- `TeamListViewModel`: `_searchQuery` + `_showOnlyWithoutCoach` StateFlows; `combine()` pipeline applies both filters on every emission from `getTeamsByClub`
- `TeamListScreen`: `FilterChip` for presidents to toggle the without-coach filter
- `strings.xml` / `values-es/strings.xml`: `team_filter_without_coach`

## Test plan
- [ ] Typing in the search bar filters teams by name in real time
- [ ] Tapping the "Without coach" chip hides teams that have a coach assigned
- [ ] Both filters work together
- [ ] Non-president users don't see the filter chip

🤖 Generated with [Claude Code](https://claude.com/claude-code)