### PR TITLE
fix: expelled members stuck in login loop on re-login

### DIFF
--- a/di/src/iosMain/kotlin/com/jesuslcorominas/teamflowmanager/di/IosModule.kt
+++ b/di/src/iosMain/kotlin/com/jesuslcorominas/teamflowmanager/di/IosModule.kt
@@ -57,7 +57,6 @@ val iosModule =
                 synchronizeTimeUseCase = get(),
                 syncFcmTokenUseCase = get(),
                 isNotificationPermissionGranted = get(),
-                signOutUseCase = get(),
             )
         }
         factory {

--- a/viewmodel/src/androidMain/kotlin/com/jesuslcorominas/teamflowmanager/viewmodel/di/ViewModelModule.kt
+++ b/viewmodel/src/androidMain/kotlin/com/jesuslcorominas/teamflowmanager/viewmodel/di/ViewModelModule.kt
@@ -44,7 +44,6 @@ val viewModelModule =
                 synchronizeTimeUseCase = get(),
                 syncFcmTokenUseCase = get(),
                 isNotificationPermissionGranted = get(),
-                signOutUseCase = get(),
             )
         }
 

--- a/viewmodel/src/androidUnitTest/kotlin/com/jesuslcorominas/teamflowmanager/viewmodel/SplashViewModelTest.kt
+++ b/viewmodel/src/androidUnitTest/kotlin/com/jesuslcorominas/teamflowmanager/viewmodel/SplashViewModelTest.kt
@@ -8,7 +8,6 @@ import com.jesuslcorominas.teamflowmanager.domain.usecase.GetCurrentUserUseCase
 import com.jesuslcorominas.teamflowmanager.domain.usecase.GetTeamUseCase
 import com.jesuslcorominas.teamflowmanager.domain.usecase.GetUserClubMembershipUseCase
 import com.jesuslcorominas.teamflowmanager.domain.usecase.IsNotificationPermissionGrantedUseCase
-import com.jesuslcorominas.teamflowmanager.domain.usecase.SignOutUseCase
 import com.jesuslcorominas.teamflowmanager.domain.usecase.SyncFcmTokenUseCase
 import com.jesuslcorominas.teamflowmanager.domain.usecase.SynchronizeTimeUseCase
 import io.mockk.coEvery
@@ -37,7 +36,6 @@ class SplashViewModelTest {
     private lateinit var synchronizeTimeUseCase: SynchronizeTimeUseCase
     private lateinit var syncFcmTokenUseCase: SyncFcmTokenUseCase
     private lateinit var isNotificationPermissionGranted: IsNotificationPermissionGrantedUseCase
-    private lateinit var signOutUseCase: SignOutUseCase
 
     private val testUser = User(
         id = "user123",
@@ -55,7 +53,6 @@ class SplashViewModelTest {
         synchronizeTimeUseCase = mockk()
         syncFcmTokenUseCase = mockk(relaxed = true)
         isNotificationPermissionGranted = mockk()
-        signOutUseCase = mockk(relaxed = true)
         coEvery { synchronizeTimeUseCase() } returns Unit
         every { isNotificationPermissionGranted() } returns false
     }
@@ -72,7 +69,6 @@ class SplashViewModelTest {
         synchronizeTimeUseCase = synchronizeTimeUseCase,
         syncFcmTokenUseCase = syncFcmTokenUseCase,
         isNotificationPermissionGranted = isNotificationPermissionGranted,
-        signOutUseCase = signOutUseCase,
     )
 
     @Test
@@ -86,7 +82,7 @@ class SplashViewModelTest {
     }
 
     @Test
-    fun `should sign out and emit NotAuthenticated when user is authenticated but has no team and no club membership`() = runTest {
+    fun `should emit NoClub when user is authenticated but has no team and no club membership`() = runTest {
         every { getCurrentUserUseCase() } returns flowOf(testUser)
         every { getTeamUseCase() } returns flowOf(null)
         every { getUserClubMembershipUseCase() } returns flowOf(null)
@@ -94,7 +90,20 @@ class SplashViewModelTest {
         val viewModel = createViewModel()
         advanceUntilIdle()
 
-        assertEquals(SplashViewModel.UiState.NotAuthenticated, viewModel.uiState.value)
+        assertEquals(SplashViewModel.UiState.NoClub, viewModel.uiState.value)
+    }
+
+    @Test
+    fun `should emit NoClub when expelled member logs in again`() = runTest {
+        // Expelled members have no clubMember document and their team's coachId is cleared
+        every { getCurrentUserUseCase() } returns flowOf(testUser)
+        every { getUserClubMembershipUseCase() } returns flowOf(null)
+        every { getTeamUseCase() } returns flowOf(null)
+
+        val viewModel = createViewModel()
+        advanceUntilIdle()
+
+        assertEquals(SplashViewModel.UiState.NoClub, viewModel.uiState.value)
     }
 
     @Test

--- a/viewmodel/src/commonMain/kotlin/com/jesuslcorominas/teamflowmanager/viewmodel/SplashViewModel.kt
+++ b/viewmodel/src/commonMain/kotlin/com/jesuslcorominas/teamflowmanager/viewmodel/SplashViewModel.kt
@@ -8,7 +8,6 @@ import com.jesuslcorominas.teamflowmanager.domain.usecase.GetCurrentUserUseCase
 import com.jesuslcorominas.teamflowmanager.domain.usecase.GetTeamUseCase
 import com.jesuslcorominas.teamflowmanager.domain.usecase.GetUserClubMembershipUseCase
 import com.jesuslcorominas.teamflowmanager.domain.usecase.IsNotificationPermissionGrantedUseCase
-import com.jesuslcorominas.teamflowmanager.domain.usecase.SignOutUseCase
 import com.jesuslcorominas.teamflowmanager.domain.usecase.SyncFcmTokenUseCase
 import com.jesuslcorominas.teamflowmanager.domain.usecase.SynchronizeTimeUseCase
 import kotlinx.coroutines.Job
@@ -25,7 +24,6 @@ class SplashViewModel(
     private val synchronizeTimeUseCase: SynchronizeTimeUseCase,
     private val syncFcmTokenUseCase: SyncFcmTokenUseCase,
     private val isNotificationPermissionGranted: IsNotificationPermissionGrantedUseCase,
-    private val signOutUseCase: SignOutUseCase,
 ) : ViewModel() {
     private val _uiState = MutableStateFlow<UiState>(UiState.Loading)
     val uiState: StateFlow<UiState> = _uiState.asStateFlow()
@@ -93,10 +91,10 @@ class SplashViewModel(
 
         if (team == null) {
             if (clubMember == null) {
-                // Authenticated but onboarding never completed — invalidate the session
-                // so the user is sent back to Login instead of the club selection screen.
-                runCatching { signOutUseCase() }
-                _uiState.value = UiState.NotAuthenticated
+                // No club membership and no team: covers expelled members and new users
+                // who never completed onboarding. Send them to club selection so they
+                // can join or create a club.
+                _uiState.value = UiState.NoClub
             } else {
                 // Member belongs to a club but has no team assigned yet — show waiting screen.
                 _uiState.value = UiState.NoTeam


### PR DESCRIPTION
## Problema

Un miembro expulsado del club intentaba volver a iniciar sesión y la app se quedaba atascada en la pantalla de Login sin avanzar.

**Causa raíz:** Al expulsar a un miembro se elimina su documento `clubMember` y se borra el `coachId` de su equipo. Al volver a hacer login, `SplashViewModel.loadTeam()` encontraba `clubMember == null` y `team == null`, y en ese caso **cerraba la sesión** y emitía `NotAuthenticated` — lo que mandaba al usuario de vuelta a Login, creando un loop infinito.

## Fix

Cambio en `SplashViewModel.loadTeam()`:

```
// Antes
if (clubMember == null) {
    runCatching { signOutUseCase() }
    _uiState.value = UiState.NotAuthenticated  // → loop
}

// Después
if (clubMember == null) {
    _uiState.value = UiState.NoClub  // → pantalla de selección de club
}
```

Un usuario autenticado sin club ni equipo (tanto expulsado como nuevo sin onboarding completo) debe ir a la selección de club, no ser desconectado.

## Cambios

- `SplashViewModel`: elimina sign-out del branch `clubMember == null`, emite `NoClub` en su lugar. Elimina el parámetro `signOutUseCase` ya innecesario.
- `ViewModelModule` + `IosModule`: quita `signOutUseCase = get()` del factory de `SplashViewModel`.
- `SplashViewModelTest`: actualiza test existente (`NotAuthenticated` → `NoClub`) y añade test explícito para el caso de miembro expulsado.

## Test plan

- [ ] Expulsar a un miembro del club que era Coach
- [ ] Iniciar sesión con ese miembro
- [ ] Verificar que navega a la pantalla de selección de club (crear/unirse)
- [ ] Verificar que no queda en bucle en Login

🤖 Generated with [Claude Code](https://claude.com/claude-code)