### PR TITLE
security: add credential leak detection to pre-push hook

### DIFF
--- a/.claude/agents/android-pr-reviewer.md
+++ b/.claude/agents/android-pr-reviewer.md
@@ -33,6 +33,17 @@ gh pr diff <PR> --repo <owner/repo>
 - Obvious risks
 - Repository/DataSource cohesion (see below)
 - Class size (see below)
+- Credential leaks (see below)
+
+### Credential leak check
+
+Scan every `+` line in the diff for:
+- Google/Firebase API keys: `AIza[0-9A-Za-z_-]{35}`
+- Private keys: `-----BEGIN (RSA |EC |OPENSSH )?PRIVATE KEY`
+- Service account JSON content: `"private_key"\s*:\s*"-----BEGIN`
+- Files that should never be committed: `google-services.json`, `GoogleService-Info.plist`, `*.keystore`, `*.jks` (unless clearly a test fixture)
+
+Flag any match as **Crítico**.
 
 ### Repository / DataSource cohesion check
 
@@ -70,6 +81,8 @@ For every file touched in the diff:
 ## Cohesión de repos/datasources
 
 ## Tamaño de clases
+
+## Seguridad
 
 ## Veredicto final
 

--- a/scripts/hooks/pre-push
+++ b/scripts/hooks/pre-push
@@ -18,6 +18,35 @@ while read local_ref local_sha remote_ref remote_sha; do
   fi
 done
 
+# ── 0. Credential leak scan ──────────────────────────────────────────────────
+echo "🔐 Scanning for credential leaks..."
+
+if [[ "$remote_sha" == "0000000000000000000000000000000000000000" ]]; then
+  DIFF_OUTPUT=$(git log -p --not --remotes=origin "$local_sha" 2>/dev/null)
+else
+  DIFF_OUTPUT=$(git diff "$remote_sha..$local_sha" 2>/dev/null)
+fi
+
+CREDENTIAL_PATTERNS=(
+  'AIza[0-9A-Za-z_\-]{35}'
+  '-----BEGIN[[:space:]]+(RSA[[:space:]]+|EC[[:space:]]+|OPENSSH[[:space:]]+)?PRIVATE KEY'
+  '"private_key"[[:space:]]*:[[:space:]]*"-----BEGIN'
+)
+
+LEAK_FOUND=0
+for pattern in "${CREDENTIAL_PATTERNS[@]}"; do
+  if echo "$DIFF_OUTPUT" | grep -qE "^\+.*${pattern}"; then
+    echo "❌ Potential credential leak — pattern: ${pattern}"
+    LEAK_FOUND=1
+  fi
+done
+
+if [ $LEAK_FOUND -ne 0 ]; then
+  echo "   Remove sensitive data before pushing. Use Secret Manager or GitHub Secrets instead."
+  exit 1
+fi
+echo "✅ No credential leaks detected"
+
 BRANCH=$(git symbolic-ref --short HEAD 2>/dev/null)
 
 # Skip protected integration branches — CI handles them


### PR DESCRIPTION
## What

- Add credential leak scan to pre-push hook (`scripts/hooks/pre-push`) that detects Google API keys, private keys, and service account JSON content
- Update PR reviewer agent documentation (`.claude/agents/android-pr-reviewer.md`) with credential leak check guidelines

## Why

Closes #

Prevent accidental commit of credentials (API keys, private keys, service account files) to version control by scanning all commits before push.

## How

Pre-push hook uses regex patterns to detect:
- Google/Firebase API keys: `AIza[0-9A-Za-z_-]{35}`
- Private keys: `-----BEGIN (RSA |EC |OPENSSH )?PRIVATE KEY`
- Service account JSON: `"private_key"\s*:\s*"-----BEGIN`

Hook fails the push if any pattern is found, preventing credential leaks.

## Test plan

- [x] Credential scan triggers on matching patterns
- [x] Scan applies to all commits not yet on remote
- [x] Manual verification of regex patterns

## Checklist

- [x] Fulfills the task / issue scope (no out-of-scope changes)
- [x] All tests pass
- [x] Lint passes
- [x] No new technical debt introduced

🤖 Generated with Claude Code