### PR TITLE
fix: president can navigate to in-progress match detail (#353)

### DIFF
--- a/shared-ui/src/commonMain/kotlin/com/jesuslcorominas/teamflowmanager/ui/club/PresidentTeamDetailScreen.kt
+++ b/shared-ui/src/commonMain/kotlin/com/jesuslcorominas/teamflowmanager/ui/club/PresidentTeamDetailScreen.kt
@@ -1,5 +1,6 @@
 package com.jesuslcorominas.teamflowmanager.ui.club
 
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
@@ -252,14 +253,17 @@ private fun MatchesTab(
             verticalArrangement = Arrangement.spacedBy(8.dp),
         ) {
             items(state.matches, key = { it.id }) { match ->
-                if (match.status == MatchStatus.FINISHED) {
-                    PlayedMatchCard(
+                when (match.status) {
+                    MatchStatus.FINISHED -> PlayedMatchCard(
                         match = match,
                         onNavigateToDetail = { onNavigateToMatch(match.id) },
                         showArchiveButton = false,
                     )
-                } else {
-                    ScheduledMatchCard(match = match)
+                    MatchStatus.IN_PROGRESS, MatchStatus.TIMEOUT -> ScheduledMatchCard(
+                        match = match,
+                        onClick = { onNavigateToMatch(match.id) },
+                    )
+                    else -> ScheduledMatchCard(match = match)
                 }
             }
         }
@@ -317,8 +321,11 @@ private fun StatsTab(stats: PresidentTeamStats) {
 }
 
 @Composable
-private fun ScheduledMatchCard(match: Match) {
-    AppCard {
+private fun ScheduledMatchCard(
+    match: Match,
+    onClick: (() -> Unit)? = null,
+) {
+    AppCard(modifier = if (onClick != null) Modifier.clickable { onClick() } else Modifier) {
         Column(
             modifier =
                 Modifier

--- a/shared-ui/src/commonMain/kotlin/com/jesuslcorominas/teamflowmanager/ui/club/PresidentTeamDetailScreen.kt
+++ b/shared-ui/src/commonMain/kotlin/com/jesuslcorominas/teamflowmanager/ui/club/PresidentTeamDetailScreen.kt
@@ -254,15 +254,17 @@ private fun MatchesTab(
         ) {
             items(state.matches, key = { it.id }) { match ->
                 when (match.status) {
-                    MatchStatus.FINISHED -> PlayedMatchCard(
-                        match = match,
-                        onNavigateToDetail = { onNavigateToMatch(match.id) },
-                        showArchiveButton = false,
-                    )
-                    MatchStatus.IN_PROGRESS, MatchStatus.TIMEOUT -> ScheduledMatchCard(
-                        match = match,
-                        onClick = { onNavigateToMatch(match.id) },
-                    )
+                    MatchStatus.FINISHED ->
+                        PlayedMatchCard(
+                            match = match,
+                            onNavigateToDetail = { onNavigateToMatch(match.id) },
+                            showArchiveButton = false,
+                        )
+                    MatchStatus.IN_PROGRESS, MatchStatus.TIMEOUT ->
+                        ScheduledMatchCard(
+                            match = match,
+                            onClick = { onNavigateToMatch(match.id) },
+                        )
                     else -> ScheduledMatchCard(match = match)
                 }
             }


### PR DESCRIPTION
## Summary

Fixes a navigation bug where tapping an in-progress match from the president's team detail screen did nothing.

- The `MatchesTab` `when` block now handles `IN_PROGRESS` and `TIMEOUT` status matches by passing `onNavigateToMatch` to `ScheduledMatchCard`, the same way `FINISHED` matches already navigated via `PlayedMatchCard`.
- `ScheduledMatchCard` accepts a new optional `onClick: (() -> Unit)? = null` parameter; a `clickable` modifier is applied only when a handler is provided, so scheduled (future) match cards remain non-clickable.

## Test plan

- [ ] Log in as president, open a team that has an in-progress match → tap the card → navigates to `MatchScreen` in read-only mode.
- [ ] Tap a finished match → still navigates correctly.
- [ ] Tap a scheduled (future) match → no navigation (unchanged behaviour).

Closes #353

🤖 Generated with [Claude Code](https://claude.com/claude-code)