### PR TITLE
feat: show LIVE badge, score, elapsed time and period on president match card (#354)

### DIFF
--- a/di/src/iosMain/kotlin/com/jesuslcorominas/teamflowmanager/di/IosModule.kt
+++ b/di/src/iosMain/kotlin/com/jesuslcorominas/teamflowmanager/di/IosModule.kt
@@ -269,6 +269,7 @@ val iosModule =
                 getTeamById = get(),
                 getPlayersByTeam = get(),
                 getMatchesByTeam = get(),
+                timeTicker = get(),
             )
         }
 

--- a/shared-ui/src/commonMain/kotlin/com/jesuslcorominas/teamflowmanager/ui/club/PresidentTeamDetailScreen.kt
+++ b/shared-ui/src/commonMain/kotlin/com/jesuslcorominas/teamflowmanager/ui/club/PresidentTeamDetailScreen.kt
@@ -1,7 +1,9 @@
 package com.jesuslcorominas.teamflowmanager.ui.club
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
@@ -18,6 +20,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
@@ -25,6 +28,8 @@ import com.jesuslcorominas.teamflowmanager.domain.analytics.ScreenName
 import com.jesuslcorominas.teamflowmanager.domain.model.GlobalNotificationState
 import com.jesuslcorominas.teamflowmanager.domain.model.Match
 import com.jesuslcorominas.teamflowmanager.domain.model.MatchStatus
+import com.jesuslcorominas.teamflowmanager.domain.model.PeriodType
+import com.jesuslcorominas.teamflowmanager.ui.util.formatTime
 import com.jesuslcorominas.teamflowmanager.ui.analytics.TrackScreenView
 import com.jesuslcorominas.teamflowmanager.ui.components.AppBackHandler
 import com.jesuslcorominas.teamflowmanager.ui.components.EmptyContent
@@ -62,7 +67,14 @@ import teamflowmanager.shared_ui.generated.resources.president_team_stats_losses
 import teamflowmanager.shared_ui.generated.resources.president_team_stats_played
 import teamflowmanager.shared_ui.generated.resources.president_team_stats_squad_size
 import teamflowmanager.shared_ui.generated.resources.president_team_stats_wins
+import teamflowmanager.shared_ui.generated.resources.first_half
+import teamflowmanager.shared_ui.generated.resources.first_quarter
+import teamflowmanager.shared_ui.generated.resources.fourth_quarter
+import teamflowmanager.shared_ui.generated.resources.match_live_badge
+import teamflowmanager.shared_ui.generated.resources.second_half
+import teamflowmanager.shared_ui.generated.resources.second_quarter
 import teamflowmanager.shared_ui.generated.resources.summary_tab
+import teamflowmanager.shared_ui.generated.resources.third_quarter
 
 @Composable
 fun PresidentTeamDetailScreen(
@@ -75,6 +87,7 @@ fun PresidentTeamDetailScreen(
 
     val uiState by viewModel.uiState.collectAsState()
     val selectedTab by viewModel.selectedTab.collectAsState()
+    val currentTime by viewModel.currentTime.collectAsState()
 
     AppBackHandler {
         if (selectedTab != PresidentTeamTab.SUMMARY) {
@@ -125,7 +138,7 @@ fun PresidentTeamDetailScreen(
                 when (selectedTab) {
                     PresidentTeamTab.SUMMARY -> SummaryTab(state)
                     PresidentTeamTab.PLAYERS -> PlayersTab(state)
-                    PresidentTeamTab.MATCHES -> MatchesTab(state, onNavigateToMatch)
+                    PresidentTeamTab.MATCHES -> MatchesTab(state, currentTime, onNavigateToMatch)
                     PresidentTeamTab.STATS -> StatsTab(state.stats)
                     PresidentTeamTab.NOTIFICATIONS -> {
                         val teamNotificationState by viewModel.teamNotificationState.collectAsState()
@@ -242,6 +255,7 @@ private fun PlayersTab(state: PresidentTeamDetailUiState.Ready) {
 @Composable
 private fun MatchesTab(
     state: PresidentTeamDetailUiState.Ready,
+    currentTime: Long,
     onNavigateToMatch: (Long) -> Unit,
 ) {
     if (state.matches.isEmpty()) {
@@ -254,17 +268,16 @@ private fun MatchesTab(
         ) {
             items(state.matches, key = { it.id }) { match ->
                 when (match.status) {
-                    MatchStatus.FINISHED ->
-                        PlayedMatchCard(
-                            match = match,
-                            onNavigateToDetail = { onNavigateToMatch(match.id) },
-                            showArchiveButton = false,
-                        )
-                    MatchStatus.IN_PROGRESS, MatchStatus.TIMEOUT ->
-                        ScheduledMatchCard(
-                            match = match,
-                            onClick = { onNavigateToMatch(match.id) },
-                        )
+                    MatchStatus.FINISHED -> PlayedMatchCard(
+                        match = match,
+                        onNavigateToDetail = { onNavigateToMatch(match.id) },
+                        showArchiveButton = false,
+                    )
+                    MatchStatus.IN_PROGRESS, MatchStatus.TIMEOUT -> LiveMatchCard(
+                        match = match,
+                        currentTime = currentTime,
+                        onNavigateToDetail = { onNavigateToMatch(match.id) },
+                    )
                     else -> ScheduledMatchCard(match = match)
                 }
             }
@@ -315,6 +328,92 @@ private fun StatsTab(stats: PresidentTeamStats) {
                     LabelValueRow(
                         label = stringResource(Res.string.president_team_stats_squad_size),
                         value = stats.squadSize.toString(),
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun LiveMatchCard(
+    match: Match,
+    currentTime: Long,
+    onNavigateToDetail: () -> Unit,
+) {
+    val activePeriod = match.periods.firstOrNull { it.startTimeMillis > 0L && it.endTimeMillis == 0L }
+    val periodLabel = activePeriod?.let { period ->
+        when (match.periodType) {
+            PeriodType.HALF_TIME -> when (period.periodNumber) {
+                1 -> stringResource(Res.string.first_half)
+                else -> stringResource(Res.string.second_half)
+            }
+            PeriodType.QUARTER_TIME -> when (period.periodNumber) {
+                1 -> stringResource(Res.string.first_quarter)
+                2 -> stringResource(Res.string.second_quarter)
+                3 -> stringResource(Res.string.third_quarter)
+                else -> stringResource(Res.string.fourth_quarter)
+            }
+        }
+    } ?: ""
+    val elapsedMillis = match.getTotalElapsed(currentTime)
+
+    AppCard(modifier = Modifier.clickable { onNavigateToDetail() }) {
+        Column(
+            modifier = Modifier.fillMaxWidth().padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(6.dp),
+        ) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Text(
+                    text = match.opponent,
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.SemiBold,
+                )
+                Box(
+                    modifier =
+                        Modifier
+                            .background(
+                                color = MaterialTheme.colorScheme.error,
+                                shape = MaterialTheme.shapes.extraSmall,
+                            )
+                            .padding(horizontal = 6.dp, vertical = 2.dp),
+                ) {
+                    Text(
+                        text = stringResource(Res.string.match_live_badge),
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.onError,
+                        fontWeight = FontWeight.Bold,
+                    )
+                }
+            }
+            Text(
+                text = "${match.goals} – ${match.opponentGoals}",
+                style = MaterialTheme.typography.titleLarge,
+                fontWeight = FontWeight.Bold,
+            )
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Text(
+                    text = formatTime(elapsedMillis),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                if (periodLabel.isNotBlank()) {
+                    Text(
+                        text = "·",
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                    Text(
+                        text = periodLabel,
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
                     )
                 }
             }

--- a/shared-ui/src/commonMain/kotlin/com/jesuslcorominas/teamflowmanager/ui/club/PresidentTeamDetailScreen.kt
+++ b/shared-ui/src/commonMain/kotlin/com/jesuslcorominas/teamflowmanager/ui/club/PresidentTeamDetailScreen.kt
@@ -29,7 +29,6 @@ import com.jesuslcorominas.teamflowmanager.domain.model.GlobalNotificationState
 import com.jesuslcorominas.teamflowmanager.domain.model.Match
 import com.jesuslcorominas.teamflowmanager.domain.model.MatchStatus
 import com.jesuslcorominas.teamflowmanager.domain.model.PeriodType
-import com.jesuslcorominas.teamflowmanager.ui.util.formatTime
 import com.jesuslcorominas.teamflowmanager.ui.analytics.TrackScreenView
 import com.jesuslcorominas.teamflowmanager.ui.components.AppBackHandler
 import com.jesuslcorominas.teamflowmanager.ui.components.EmptyContent
@@ -38,6 +37,7 @@ import com.jesuslcorominas.teamflowmanager.ui.components.card.AppCard
 import com.jesuslcorominas.teamflowmanager.ui.matches.card.PlayedMatchCard
 import com.jesuslcorominas.teamflowmanager.ui.players.components.PlayerList
 import com.jesuslcorominas.teamflowmanager.ui.util.DateFormatter
+import com.jesuslcorominas.teamflowmanager.ui.util.formatTime
 import com.jesuslcorominas.teamflowmanager.viewmodel.PresidentTeamDetailUiState
 import com.jesuslcorominas.teamflowmanager.viewmodel.PresidentTeamDetailViewModel
 import com.jesuslcorominas.teamflowmanager.viewmodel.PresidentTeamStats
@@ -48,6 +48,10 @@ import org.koin.core.parameter.parametersOf
 import teamflowmanager.shared_ui.generated.resources.Res
 import teamflowmanager.shared_ui.generated.resources.coach_name
 import teamflowmanager.shared_ui.generated.resources.delegate_name
+import teamflowmanager.shared_ui.generated.resources.first_half
+import teamflowmanager.shared_ui.generated.resources.first_quarter
+import teamflowmanager.shared_ui.generated.resources.fourth_quarter
+import teamflowmanager.shared_ui.generated.resources.match_live_badge
 import teamflowmanager.shared_ui.generated.resources.president_notifications_global_mixed
 import teamflowmanager.shared_ui.generated.resources.president_notifications_global_off
 import teamflowmanager.shared_ui.generated.resources.president_notifications_global_on
@@ -67,10 +71,6 @@ import teamflowmanager.shared_ui.generated.resources.president_team_stats_losses
 import teamflowmanager.shared_ui.generated.resources.president_team_stats_played
 import teamflowmanager.shared_ui.generated.resources.president_team_stats_squad_size
 import teamflowmanager.shared_ui.generated.resources.president_team_stats_wins
-import teamflowmanager.shared_ui.generated.resources.first_half
-import teamflowmanager.shared_ui.generated.resources.first_quarter
-import teamflowmanager.shared_ui.generated.resources.fourth_quarter
-import teamflowmanager.shared_ui.generated.resources.match_live_badge
 import teamflowmanager.shared_ui.generated.resources.second_half
 import teamflowmanager.shared_ui.generated.resources.second_quarter
 import teamflowmanager.shared_ui.generated.resources.summary_tab
@@ -268,16 +268,18 @@ private fun MatchesTab(
         ) {
             items(state.matches, key = { it.id }) { match ->
                 when (match.status) {
-                    MatchStatus.FINISHED -> PlayedMatchCard(
-                        match = match,
-                        onNavigateToDetail = { onNavigateToMatch(match.id) },
-                        showArchiveButton = false,
-                    )
-                    MatchStatus.IN_PROGRESS, MatchStatus.TIMEOUT -> LiveMatchCard(
-                        match = match,
-                        currentTime = currentTime,
-                        onNavigateToDetail = { onNavigateToMatch(match.id) },
-                    )
+                    MatchStatus.FINISHED ->
+                        PlayedMatchCard(
+                            match = match,
+                            onNavigateToDetail = { onNavigateToMatch(match.id) },
+                            showArchiveButton = false,
+                        )
+                    MatchStatus.IN_PROGRESS, MatchStatus.TIMEOUT ->
+                        LiveMatchCard(
+                            match = match,
+                            currentTime = currentTime,
+                            onNavigateToDetail = { onNavigateToMatch(match.id) },
+                        )
                     else -> ScheduledMatchCard(match = match)
                 }
             }
@@ -342,20 +344,23 @@ private fun LiveMatchCard(
     onNavigateToDetail: () -> Unit,
 ) {
     val activePeriod = match.periods.firstOrNull { it.startTimeMillis > 0L && it.endTimeMillis == 0L }
-    val periodLabel = activePeriod?.let { period ->
-        when (match.periodType) {
-            PeriodType.HALF_TIME -> when (period.periodNumber) {
-                1 -> stringResource(Res.string.first_half)
-                else -> stringResource(Res.string.second_half)
+    val periodLabel =
+        activePeriod?.let { period ->
+            when (match.periodType) {
+                PeriodType.HALF_TIME ->
+                    when (period.periodNumber) {
+                        1 -> stringResource(Res.string.first_half)
+                        else -> stringResource(Res.string.second_half)
+                    }
+                PeriodType.QUARTER_TIME ->
+                    when (period.periodNumber) {
+                        1 -> stringResource(Res.string.first_quarter)
+                        2 -> stringResource(Res.string.second_quarter)
+                        3 -> stringResource(Res.string.third_quarter)
+                        else -> stringResource(Res.string.fourth_quarter)
+                    }
             }
-            PeriodType.QUARTER_TIME -> when (period.periodNumber) {
-                1 -> stringResource(Res.string.first_quarter)
-                2 -> stringResource(Res.string.second_quarter)
-                3 -> stringResource(Res.string.third_quarter)
-                else -> stringResource(Res.string.fourth_quarter)
-            }
-        }
-    } ?: ""
+        } ?: ""
     val elapsedMillis = match.getTotalElapsed(currentTime)
 
     AppCard(modifier = Modifier.clickable { onNavigateToDetail() }) {

--- a/viewmodel/src/androidMain/kotlin/com/jesuslcorominas/teamflowmanager/viewmodel/di/ViewModelModule.kt
+++ b/viewmodel/src/androidMain/kotlin/com/jesuslcorominas/teamflowmanager/viewmodel/di/ViewModelModule.kt
@@ -258,6 +258,7 @@ val viewModelModule =
                 getNotificationPreferences = get(),
                 updateTeamNotificationPreference = get(),
                 getUserClubMembership = get(),
+                timeTicker = get(),
             )
         }
 

--- a/viewmodel/src/commonMain/kotlin/com/jesuslcorominas/teamflowmanager/viewmodel/PresidentTeamDetailViewModel.kt
+++ b/viewmodel/src/commonMain/kotlin/com/jesuslcorominas/teamflowmanager/viewmodel/PresidentTeamDetailViewModel.kt
@@ -14,6 +14,7 @@ import com.jesuslcorominas.teamflowmanager.domain.usecase.GetPlayersByTeamUseCas
 import com.jesuslcorominas.teamflowmanager.domain.usecase.GetTeamByIdUseCase
 import com.jesuslcorominas.teamflowmanager.domain.usecase.GetUserClubMembershipUseCase
 import com.jesuslcorominas.teamflowmanager.domain.usecase.UpdateTeamNotificationPreferenceUseCase
+import com.jesuslcorominas.teamflowmanager.viewmodel.utils.TimeTicker
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -54,12 +55,16 @@ class PresidentTeamDetailViewModel(
     private val getNotificationPreferences: GetNotificationPreferencesUseCase,
     private val updateTeamNotificationPreference: UpdateTeamNotificationPreferenceUseCase,
     private val getUserClubMembership: GetUserClubMembershipUseCase,
+    private val timeTicker: TimeTicker,
 ) : ViewModel() {
     private val _uiState = MutableStateFlow<PresidentTeamDetailUiState>(PresidentTeamDetailUiState.Loading)
     val uiState: StateFlow<PresidentTeamDetailUiState> = _uiState.asStateFlow()
 
     private val _selectedTab = MutableStateFlow(PresidentTeamTab.SUMMARY)
     val selectedTab: StateFlow<PresidentTeamTab> = _selectedTab.asStateFlow()
+
+    private val _currentTime = MutableStateFlow(0L)
+    val currentTime: StateFlow<Long> = _currentTime.asStateFlow()
 
     data class TeamNotificationPreferencesState(
         val matchEvents: Boolean = true,
@@ -74,6 +79,11 @@ class PresidentTeamDetailViewModel(
 
     init {
         load()
+        viewModelScope.launch {
+            timeTicker.timeFlow.collect { now ->
+                _currentTime.value = now
+            }
+        }
     }
 
     fun selectTab(tab: PresidentTeamTab) {


### PR DESCRIPTION
## Summary

Adds live match information to the match cards displayed in the president's team detail → Matches tab when a match is `IN_PROGRESS` or `TIMEOUT`.

- **`PresidentTeamDetailViewModel`**: Added `TimeTicker` dependency and a `currentTime: StateFlow<Long>` that emits the current wall-clock time every second. DI modules (Android `ViewModelModule` and iOS `IosModule`) updated to inject `timeTicker = get()`.
- **`LiveMatchCard`** (new composable): Shown for `IN_PROGRESS`/`TIMEOUT` matches. Displays:
  - Red **LIVE** badge (reuses `match_live_badge` string and the same `Box + background(error)` style from `MatchStatusSection` in the team list screen).
  - Live **score** (`goals – opponentGoals`).
  - **Elapsed time** in `mm:ss` via `formatTime(match.getTotalElapsed(currentTime))`.
  - **Active period label** (`1st Half`, `2nd Half`, `1st Quarter` … `4th Quarter`) derived from the first period with `startTimeMillis > 0` and `endTimeMillis == 0`.
  - Tapping the card navigates to `MatchScreen` in read-only mode (also fixes #353 for `IN_PROGRESS`/`TIMEOUT`).
- `MatchesTab` updated to route `IN_PROGRESS`/`TIMEOUT` matches to `LiveMatchCard`, passing `currentTime` collected from the ViewModel. `FINISHED` and `SCHEDULED` matches are unaffected.

## Test plan

- [ ] President opens team detail → Matches tab with an in-progress match → card shows LIVE badge, score, elapsed time (`mm:ss`, updating live) and period label.
- [ ] Elapsed time and score update in real time without navigating away.
- [ ] `TIMEOUT` match also shows LIVE badge and live data.
- [ ] Finished match card is unchanged.
- [ ] Scheduled (future) match card is unchanged.
- [ ] Tapping the live card navigates to `MatchScreen(readOnly = true)`.

Closes #354

🤖 Generated with [Claude Code](https://claude.com/claude-code)