### PR TITLE
fix: homeGround suggestion chip always visible on match creation wizard

### DIFF
--- a/shared-ui/src/commonMain/kotlin/com/jesuslcorominas/teamflowmanager/ui/matches/wizard/MatchCreationWizardScreen.kt
+++ b/shared-ui/src/commonMain/kotlin/com/jesuslcorominas/teamflowmanager/ui/matches/wizard/MatchCreationWizardScreen.kt
@@ -55,6 +55,7 @@ fun MatchCreationWizardScreen(
     val uiState by wizardViewModel.uiState.collectAsState()
     val currentStep by wizardViewModel.currentStep.collectAsState()
     val showExitDialog by wizardViewModel.showExitDialog.collectAsState()
+    val homeGround by wizardViewModel.homeGround.collectAsState()
     val scope = rememberCoroutineScope()
 
     var showDefaultCaptainDialog by remember { mutableStateOf(false) }
@@ -81,7 +82,7 @@ fun MatchCreationWizardScreen(
                                 onDataChanged = { opponent, location, date, time, numberOfPeriods ->
                                     wizardViewModel.setGeneralData(opponent, location, date, time, numberOfPeriods)
                                 },
-                                homeGround = wizardViewModel.getHomeGround(),
+                                homeGround = homeGround,
                                 onNext = { wizardViewModel.goToNextStep() },
                                 onCancel = { wizardViewModel.requestBack(onNavigateBack) },
                                 modifier =

--- a/viewmodel/src/commonMain/kotlin/com/jesuslcorominas/teamflowmanager/viewmodel/MatchCreationWizardViewModel.kt
+++ b/viewmodel/src/commonMain/kotlin/com/jesuslcorominas/teamflowmanager/viewmodel/MatchCreationWizardViewModel.kt
@@ -76,7 +76,8 @@ class MatchCreationWizardViewModel(
     private var activeMatchId: Long = matchId
     private var isEditMode = matchId != 0L
     private var teamTypeValue: Int = 5 // Default to Football 5
-    private var homeGround: String? = null
+    private val _homeGround = MutableStateFlow<String?>(null)
+    val homeGround: StateFlow<String?> = _homeGround.asStateFlow()
 
     // Flag to track if match data is loaded for edit mode
     private var matchDataLoaded = false
@@ -131,7 +132,7 @@ class MatchCreationWizardViewModel(
 
         matchDataLoaded = false
         playersLoaded = false
-        homeGround = null
+        _homeGround.value = null
         pendingMatchIdForEdit = if (newMatchId != 0L) newMatchId else null
 
         _uiState.value = MatchCreationWizardUiState.Loading
@@ -147,7 +148,7 @@ class MatchCreationWizardViewModel(
             val team = getTeamUseCase.invoke().first()
             teamTypeValue = team?.teamType?.players ?: 5
             team?.clubRemoteId?.let { remoteId ->
-                homeGround = getClubByIdUseCase.invoke(remoteId)?.homeGround
+                _homeGround.value = getClubByIdUseCase.invoke(remoteId)?.homeGround
             }
         }
     }
@@ -257,8 +258,6 @@ class MatchCreationWizardViewModel(
     fun getStartingLineupIds() = startingLineupIds
 
     fun getTeamTypePlayerCount() = teamTypeValue
-
-    fun getHomeGround() = homeGround
 
     fun goToNextStep() {
         viewModelScope.launch {


### PR DESCRIPTION
## Summary

- `homeGround` era un `var` plano en `MatchCreationWizardViewModel`, por lo que Compose no podía observarlo
- `loadTeam()` corre de forma asíncrona y puede completarse después de la composición inicial, dejando el chip sin renderizar
- Se convierte `homeGround` a `StateFlow<String?>` y se recoge con `collectAsState()` en la pantalla, garantizando que el chip del lugar de juego siempre aparece una vez llegan los datos del club

## Test plan

- [ ] Crear un partido nuevo → verificar que el chip con el campo local aparece siempre (no solo a veces)
- [ ] Verificar que al pulsar el chip se rellena el campo de localización
- [ ] Verificar que editar un partido existente sigue funcionando correctamente

🤖 Generated with [Claude Code](https://claude.com/claude-code)