### PR TITLE
fix: cargar documentos Firestore legacy en iOS y en los agregados (#385)

### DIFF
--- a/data/remote/src/androidMain/kotlin/com/jesuslcorominas/teamflowmanager/data/remote/datasource/GoalFirestoreDataSourceImpl.kt
+++ b/data/remote/src/androidMain/kotlin/com/jesuslcorominas/teamflowmanager/data/remote/datasource/GoalFirestoreDataSourceImpl.kt
@@ -3,8 +3,7 @@ package com.jesuslcorominas.teamflowmanager.data.remote.datasource
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.firestore.FirebaseFirestore
 import com.jesuslcorominas.teamflowmanager.data.core.datasource.GoalDataSource
-import com.jesuslcorominas.teamflowmanager.data.remote.firestore.GoalFirestoreModel
-import com.jesuslcorominas.teamflowmanager.data.remote.firestore.toDomain
+import com.jesuslcorominas.teamflowmanager.data.remote.firestore.parseGoalDocument
 import com.jesuslcorominas.teamflowmanager.data.remote.firestore.toFirestoreModel
 import com.jesuslcorominas.teamflowmanager.data.remote.util.toLegacyId
 import com.jesuslcorominas.teamflowmanager.domain.model.Goal
@@ -53,36 +52,6 @@ class GoalFirestoreDataSourceImpl(
             } catch (_: Exception) {
                 null
             }
-
-    private fun parseGoalDocument(
-        rawData: Map<String, Any?>?,
-        docId: String,
-        teamDocId: String,
-        matchId: String,
-    ): Goal? {
-        if (rawData == null) return null
-        return try {
-            val rawScorerId = rawData["scorerId"]?.toString()
-            val model =
-                try {
-                    GoalFirestoreModel(
-                        id = docId,
-                        teamId = rawData["teamId"] as? String ?: teamDocId,
-                        matchId = matchId,
-                        scorerId = rawScorerId,
-                        goalTimeMillis = rawData["goalTimeMillis"] as? Long ?: 0L,
-                        matchElapsedTimeMillis = rawData["matchElapsedTimeMillis"] as? Long ?: 0L,
-                        isOpponentGoal = rawData["opponentGoal"] as? Boolean ?: false,
-                        isOwnGoal = rawData["ownGoal"] as? Boolean ?: false,
-                    )
-                } catch (_: Exception) {
-                    return null
-                }
-            model.toDomain()
-        } catch (_: Exception) {
-            null
-        }
-    }
 
     override fun getMatchGoals(matchId: String): Flow<List<Goal>> =
         callbackFlow {
@@ -162,7 +131,8 @@ class GoalFirestoreDataSourceImpl(
                         }
                         val goals =
                             snapshot?.documents?.mapNotNull { document ->
-                                document.toObject(GoalFirestoreModel::class.java)?.toDomain()
+                                val rawMatchId = document.data?.get("matchId")?.toString() ?: ""
+                                parseGoalDocument(document.data, document.id, teamDocId, rawMatchId)
                             } ?: emptyList()
                         trySend(goals)
                     }

--- a/data/remote/src/androidMain/kotlin/com/jesuslcorominas/teamflowmanager/data/remote/datasource/GoalFirestoreDataSourceImpl.kt
+++ b/data/remote/src/androidMain/kotlin/com/jesuslcorominas/teamflowmanager/data/remote/datasource/GoalFirestoreDataSourceImpl.kt
@@ -79,7 +79,7 @@ class GoalFirestoreDataSourceImpl(
                         .get()
                         .await()
                         .documents.mapNotNull { document ->
-                            parseGoalDocument(document.data, document.id, teamDocId, matchId)
+                            parseGoalDocument(document.data, document.id, matchId)
                         }
                 } catch (_: Exception) {
                     emptyList()
@@ -97,7 +97,7 @@ class GoalFirestoreDataSourceImpl(
                         }
                         val newGoals =
                             snapshot?.documents?.mapNotNull { document ->
-                                parseGoalDocument(document.data, document.id, teamDocId, matchId)
+                                parseGoalDocument(document.data, document.id, matchId)
                             } ?: emptyList()
                         trySend(legacyGoals + newGoals)
                     }
@@ -132,7 +132,7 @@ class GoalFirestoreDataSourceImpl(
                         val goals =
                             snapshot?.documents?.mapNotNull { document ->
                                 val rawMatchId = document.data?.get("matchId")?.toString() ?: ""
-                                parseGoalDocument(document.data, document.id, teamDocId, rawMatchId)
+                                parseGoalDocument(document.data, document.id, rawMatchId)
                             } ?: emptyList()
                         trySend(goals)
                     }

--- a/data/remote/src/androidMain/kotlin/com/jesuslcorominas/teamflowmanager/data/remote/datasource/PlayerSubstitutionFirestoreDataSourceImpl.kt
+++ b/data/remote/src/androidMain/kotlin/com/jesuslcorominas/teamflowmanager/data/remote/datasource/PlayerSubstitutionFirestoreDataSourceImpl.kt
@@ -3,8 +3,7 @@ package com.jesuslcorominas.teamflowmanager.data.remote.datasource
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.firestore.FirebaseFirestore
 import com.jesuslcorominas.teamflowmanager.data.core.datasource.PlayerSubstitutionDataSource
-import com.jesuslcorominas.teamflowmanager.data.remote.firestore.PlayerSubstitutionFirestoreModel
-import com.jesuslcorominas.teamflowmanager.data.remote.firestore.toDomain
+import com.jesuslcorominas.teamflowmanager.data.remote.firestore.parseSubstitutionDocument
 import com.jesuslcorominas.teamflowmanager.data.remote.firestore.toFirestoreModel
 import com.jesuslcorominas.teamflowmanager.data.remote.util.toLegacyId
 import com.jesuslcorominas.teamflowmanager.domain.model.PlayerSubstitution
@@ -53,30 +52,6 @@ class PlayerSubstitutionFirestoreDataSourceImpl(
             } catch (_: Exception) {
                 null
             }
-
-    private fun parseSubstitutionDocument(
-        rawData: Map<String, Any?>?,
-        docId: String,
-        teamDocId: String,
-        matchId: String,
-    ): PlayerSubstitution? {
-        if (rawData == null) return null
-        return try {
-            val rawPlayerOutId = rawData["playerOutId"]?.toString() ?: ""
-            val rawPlayerInId = rawData["playerInId"]?.toString() ?: ""
-            PlayerSubstitutionFirestoreModel(
-                id = docId,
-                teamId = rawData["teamId"] as? String ?: teamDocId,
-                matchId = matchId,
-                playerOutId = rawPlayerOutId,
-                playerInId = rawPlayerInId,
-                substitutionTimeMillis = rawData["substitutionTimeMillis"] as? Long ?: 0L,
-                matchElapsedTimeMillis = rawData["matchElapsedTimeMillis"] as? Long ?: 0L,
-            ).toDomain()
-        } catch (_: Exception) {
-            null
-        }
-    }
 
     override fun getMatchSubstitutions(matchId: String): Flow<List<PlayerSubstitution>> =
         callbackFlow {

--- a/data/remote/src/androidMain/kotlin/com/jesuslcorominas/teamflowmanager/data/remote/datasource/PlayerSubstitutionFirestoreDataSourceImpl.kt
+++ b/data/remote/src/androidMain/kotlin/com/jesuslcorominas/teamflowmanager/data/remote/datasource/PlayerSubstitutionFirestoreDataSourceImpl.kt
@@ -79,7 +79,7 @@ class PlayerSubstitutionFirestoreDataSourceImpl(
                         .get()
                         .await()
                         .documents.mapNotNull { document ->
-                            parseSubstitutionDocument(document.data, document.id, teamDocId, matchId)
+                            parseSubstitutionDocument(document.data, document.id, matchId)
                         }
                 } catch (_: Exception) {
                     emptyList()
@@ -97,7 +97,7 @@ class PlayerSubstitutionFirestoreDataSourceImpl(
                         }
                         val newSubstitutions =
                             snapshot?.documents?.mapNotNull { document ->
-                                parseSubstitutionDocument(document.data, document.id, teamDocId, matchId)
+                                parseSubstitutionDocument(document.data, document.id, matchId)
                             } ?: emptyList()
                         trySend(legacySubstitutions + newSubstitutions)
                     }

--- a/data/remote/src/androidMain/kotlin/com/jesuslcorominas/teamflowmanager/data/remote/datasource/PlayerTimeFirestoreDataSourceImpl.kt
+++ b/data/remote/src/androidMain/kotlin/com/jesuslcorominas/teamflowmanager/data/remote/datasource/PlayerTimeFirestoreDataSourceImpl.kt
@@ -162,7 +162,7 @@ class PlayerTimeFirestoreDataSourceImpl(
                         .get()
                         .await()
                         .documents.mapNotNull { document ->
-                            parsePlayerTimeDocument(document.data, document.id, teamDocId, matchId)
+                            parsePlayerTimeDocument(document.data, matchId)
                         }
                 } catch (_: Exception) {
                     emptyList()
@@ -180,7 +180,7 @@ class PlayerTimeFirestoreDataSourceImpl(
                         }
                         val newPlayerTimes =
                             snapshot?.documents?.mapNotNull { document ->
-                                parsePlayerTimeDocument(document.data, document.id, teamDocId, matchId)
+                                parsePlayerTimeDocument(document.data, matchId)
                             } ?: emptyList()
                         trySend(legacyPlayerTimes + newPlayerTimes)
                     }

--- a/data/remote/src/androidMain/kotlin/com/jesuslcorominas/teamflowmanager/data/remote/datasource/PlayerTimeFirestoreDataSourceImpl.kt
+++ b/data/remote/src/androidMain/kotlin/com/jesuslcorominas/teamflowmanager/data/remote/datasource/PlayerTimeFirestoreDataSourceImpl.kt
@@ -4,6 +4,7 @@ import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.firestore.FirebaseFirestore
 import com.jesuslcorominas.teamflowmanager.data.core.datasource.PlayerTimeDataSource
 import com.jesuslcorominas.teamflowmanager.data.remote.firestore.PlayerTimeFirestoreModel
+import com.jesuslcorominas.teamflowmanager.data.remote.firestore.parsePlayerTimeDocument
 import com.jesuslcorominas.teamflowmanager.data.remote.firestore.toDomain
 import com.jesuslcorominas.teamflowmanager.data.remote.firestore.toFirestoreModel
 import com.jesuslcorominas.teamflowmanager.data.remote.util.toLegacyId
@@ -127,31 +128,6 @@ class PlayerTimeFirestoreDataSourceImpl(
             } catch (_: Exception) {
                 null
             }
-
-    private fun parsePlayerTimeDocument(
-        rawData: Map<String, Any?>?,
-        docId: String,
-        teamDocId: String,
-        matchId: String,
-    ): PlayerTime? {
-        if (rawData == null) return null
-        return try {
-            val rawPlayerId = rawData["playerId"]?.toString() ?: ""
-            PlayerTimeFirestoreModel(
-                id = docId,
-                teamId = rawData["teamId"] as? String ?: teamDocId,
-                matchId = matchId,
-                playerId = rawPlayerId,
-                elapsedTimeMillis = rawData["elapsedTimeMillis"] as? Long ?: 0L,
-                isRunning = rawData["running"] as? Boolean ?: false,
-                lastStartTimeMillis = rawData["lastStartTimeMillis"] as? Long,
-                status = rawData["status"] as? String ?: "ON_BENCH",
-                lastOperationId = rawData["lastOperationId"] as? String,
-            ).toDomain()
-        } catch (_: Exception) {
-            null
-        }
-    }
 
     /**
      * Gets player times scoped to a specific match from Firestore as a real-time Flow.

--- a/data/remote/src/androidMain/kotlin/com/jesuslcorominas/teamflowmanager/data/remote/datasource/PlayerTimeHistoryFirestoreDataSourceImpl.kt
+++ b/data/remote/src/androidMain/kotlin/com/jesuslcorominas/teamflowmanager/data/remote/datasource/PlayerTimeHistoryFirestoreDataSourceImpl.kt
@@ -80,7 +80,7 @@ class PlayerTimeHistoryFirestoreDataSourceImpl(
                         .await()
                         .documents.mapNotNull { document ->
                             val rawMatchId = document.data?.get("matchId")?.toString() ?: ""
-                            parsePlayerTimeHistoryDocument(document.data, document.id, teamDocId, playerId, rawMatchId)
+                            parsePlayerTimeHistoryDocument(document.data, document.id, playerId, rawMatchId)
                         }
                 } catch (_: Exception) {
                     emptyList()
@@ -99,7 +99,7 @@ class PlayerTimeHistoryFirestoreDataSourceImpl(
                         val newHistory =
                             snapshot?.documents?.mapNotNull { document ->
                                 val rawMatchId = document.data?.get("matchId")?.toString() ?: ""
-                                parsePlayerTimeHistoryDocument(document.data, document.id, teamDocId, playerId, rawMatchId)
+                                parsePlayerTimeHistoryDocument(document.data, document.id, playerId, rawMatchId)
                             } ?: emptyList()
                         trySend(legacyHistory + newHistory)
                     }
@@ -134,7 +134,7 @@ class PlayerTimeHistoryFirestoreDataSourceImpl(
                         .await()
                         .documents.mapNotNull { document ->
                             val rawPlayerId = document.data?.get("playerId")?.toString() ?: ""
-                            parsePlayerTimeHistoryDocument(document.data, document.id, teamDocId, rawPlayerId, matchId)
+                            parsePlayerTimeHistoryDocument(document.data, document.id, rawPlayerId, matchId)
                         }
                 } catch (_: Exception) {
                     emptyList()
@@ -153,7 +153,7 @@ class PlayerTimeHistoryFirestoreDataSourceImpl(
                         val newHistory =
                             snapshot?.documents?.mapNotNull { document ->
                                 val rawPlayerId = document.data?.get("playerId")?.toString() ?: ""
-                                parsePlayerTimeHistoryDocument(document.data, document.id, teamDocId, rawPlayerId, matchId)
+                                parsePlayerTimeHistoryDocument(document.data, document.id, rawPlayerId, matchId)
                             } ?: emptyList()
                         trySend(legacyHistory + newHistory)
                     }
@@ -192,7 +192,6 @@ class PlayerTimeHistoryFirestoreDataSourceImpl(
                                 parsePlayerTimeHistoryDocument(
                                     document.data,
                                     document.id,
-                                    teamDocId,
                                     rawPlayerId,
                                     rawMatchId,
                                 )

--- a/data/remote/src/androidMain/kotlin/com/jesuslcorominas/teamflowmanager/data/remote/datasource/PlayerTimeHistoryFirestoreDataSourceImpl.kt
+++ b/data/remote/src/androidMain/kotlin/com/jesuslcorominas/teamflowmanager/data/remote/datasource/PlayerTimeHistoryFirestoreDataSourceImpl.kt
@@ -3,8 +3,7 @@ package com.jesuslcorominas.teamflowmanager.data.remote.datasource
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.firestore.FirebaseFirestore
 import com.jesuslcorominas.teamflowmanager.data.core.datasource.PlayerTimeHistoryDataSource
-import com.jesuslcorominas.teamflowmanager.data.remote.firestore.PlayerTimeHistoryFirestoreModel
-import com.jesuslcorominas.teamflowmanager.data.remote.firestore.toDomain
+import com.jesuslcorominas.teamflowmanager.data.remote.firestore.parsePlayerTimeHistoryDocument
 import com.jesuslcorominas.teamflowmanager.data.remote.firestore.toFirestoreModel
 import com.jesuslcorominas.teamflowmanager.data.remote.util.toLegacyId
 import com.jesuslcorominas.teamflowmanager.domain.model.PlayerTimeHistory
@@ -54,28 +53,6 @@ class PlayerTimeHistoryFirestoreDataSourceImpl(
                 null
             }
 
-    private fun parseHistoryDocument(
-        rawData: Map<String, Any?>?,
-        docId: String,
-        teamDocId: String,
-        playerId: String,
-        matchId: String,
-    ): PlayerTimeHistory? {
-        if (rawData == null) return null
-        return try {
-            PlayerTimeHistoryFirestoreModel(
-                id = docId,
-                teamId = rawData["teamId"] as? String ?: teamDocId,
-                playerId = playerId,
-                matchId = matchId,
-                elapsedTimeMillis = rawData["elapsedTimeMillis"] as? Long ?: 0L,
-                savedAtMillis = rawData["savedAtMillis"] as? Long ?: 0L,
-            ).toDomain()
-        } catch (_: Exception) {
-            null
-        }
-    }
-
     override fun getPlayerTimeHistory(playerId: String): Flow<List<PlayerTimeHistory>> =
         callbackFlow {
             val currentUserId = firebaseAuth.currentUser?.uid
@@ -103,7 +80,7 @@ class PlayerTimeHistoryFirestoreDataSourceImpl(
                         .await()
                         .documents.mapNotNull { document ->
                             val rawMatchId = document.data?.get("matchId")?.toString() ?: ""
-                            parseHistoryDocument(document.data, document.id, teamDocId, playerId, rawMatchId)
+                            parsePlayerTimeHistoryDocument(document.data, document.id, teamDocId, playerId, rawMatchId)
                         }
                 } catch (_: Exception) {
                     emptyList()
@@ -122,7 +99,7 @@ class PlayerTimeHistoryFirestoreDataSourceImpl(
                         val newHistory =
                             snapshot?.documents?.mapNotNull { document ->
                                 val rawMatchId = document.data?.get("matchId")?.toString() ?: ""
-                                parseHistoryDocument(document.data, document.id, teamDocId, playerId, rawMatchId)
+                                parsePlayerTimeHistoryDocument(document.data, document.id, teamDocId, playerId, rawMatchId)
                             } ?: emptyList()
                         trySend(legacyHistory + newHistory)
                     }
@@ -157,7 +134,7 @@ class PlayerTimeHistoryFirestoreDataSourceImpl(
                         .await()
                         .documents.mapNotNull { document ->
                             val rawPlayerId = document.data?.get("playerId")?.toString() ?: ""
-                            parseHistoryDocument(document.data, document.id, teamDocId, rawPlayerId, matchId)
+                            parsePlayerTimeHistoryDocument(document.data, document.id, teamDocId, rawPlayerId, matchId)
                         }
                 } catch (_: Exception) {
                     emptyList()
@@ -176,7 +153,7 @@ class PlayerTimeHistoryFirestoreDataSourceImpl(
                         val newHistory =
                             snapshot?.documents?.mapNotNull { document ->
                                 val rawPlayerId = document.data?.get("playerId")?.toString() ?: ""
-                                parseHistoryDocument(document.data, document.id, teamDocId, rawPlayerId, matchId)
+                                parsePlayerTimeHistoryDocument(document.data, document.id, teamDocId, rawPlayerId, matchId)
                             } ?: emptyList()
                         trySend(legacyHistory + newHistory)
                     }
@@ -210,7 +187,15 @@ class PlayerTimeHistoryFirestoreDataSourceImpl(
                         }
                         val history =
                             snapshot?.documents?.mapNotNull { document ->
-                                document.toObject(PlayerTimeHistoryFirestoreModel::class.java)?.toDomain()
+                                val rawPlayerId = document.data?.get("playerId")?.toString() ?: ""
+                                val rawMatchId = document.data?.get("matchId")?.toString() ?: ""
+                                parsePlayerTimeHistoryDocument(
+                                    document.data,
+                                    document.id,
+                                    teamDocId,
+                                    rawPlayerId,
+                                    rawMatchId,
+                                )
                             } ?: emptyList()
                         trySend(history)
                     }

--- a/data/remote/src/androidUnitTest/kotlin/com/jesuslcorominas/teamflowmanager/data/remote/datasource/GoalFirestoreDataSourceImplTest.kt
+++ b/data/remote/src/androidUnitTest/kotlin/com/jesuslcorominas/teamflowmanager/data/remote/datasource/GoalFirestoreDataSourceImplTest.kt
@@ -26,7 +26,6 @@ import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Assert.fail
-import com.jesuslcorominas.teamflowmanager.data.remote.firestore.GoalFirestoreModel
 import org.junit.After
 import org.junit.Before
 import org.junit.Test
@@ -240,12 +239,8 @@ class GoalFirestoreDataSourceImplTest {
         every { goalsCollection.whereEqualTo("teamId", "team-doc-id") } returns goalsQuery
         every { goalsQuery.addSnapshotListener(capture(listenerSlot)) } returns mockListenerRegistration
 
-        val model = GoalFirestoreModel(
-            id = "goal-doc-id",
-            teamId = "team-doc-id",
-            matchId = "1"
-        )
-        every { docSnapshot.toObject(GoalFirestoreModel::class.java) } returns model
+        every { docSnapshot.data } returns mapOf("matchId" to "1", "teamId" to "team-doc-id", "scorerId" to null)
+        every { docSnapshot.id } returns "goal-doc-id"
         every { querySnapshot.documents } returns listOf(docSnapshot)
 
         dataSource.getAllTeamGoals().test {

--- a/data/remote/src/androidUnitTest/kotlin/com/jesuslcorominas/teamflowmanager/data/remote/datasource/PlayerTimeHistoryFirestoreDataSourceImplTest.kt
+++ b/data/remote/src/androidUnitTest/kotlin/com/jesuslcorominas/teamflowmanager/data/remote/datasource/PlayerTimeHistoryFirestoreDataSourceImplTest.kt
@@ -453,19 +453,11 @@ class PlayerTimeHistoryFirestoreDataSourceImplTest {
         every { historyCollection.whereEqualTo("teamId", "team-doc-id") } returns historyQuery
         every { historyQuery.addSnapshotListener(capture(listenerSlot)) } returns mockListenerRegistration
 
-        val model = PlayerTimeHistoryFirestoreModel(
-            id = "history-doc-id",
-            teamId = "team-doc-id",
-            playerId = "1",
-            matchId = "1",
-            elapsedTimeMillis = 45000L,
-            savedAtMillis = System.currentTimeMillis()
-        )
         every { docSnapshot.data } returns mapOf(
             "playerId" to "1", "matchId" to "1", "teamId" to "team-doc-id",
+            "elapsedTimeMillis" to 45000L, "savedAtMillis" to System.currentTimeMillis(),
         )
         every { docSnapshot.id } returns "history-doc-id"
-        every { docSnapshot.toObject(PlayerTimeHistoryFirestoreModel::class.java) } returns model
         every { querySnapshot.documents } returns listOf(docSnapshot)
 
         dataSource.getAllPlayerTimeHistory().test {

--- a/data/remote/src/commonMain/kotlin/com/jesuslcorominas/teamflowmanager/data/remote/firestore/LegacyDocumentParsers.kt
+++ b/data/remote/src/commonMain/kotlin/com/jesuslcorominas/teamflowmanager/data/remote/firestore/LegacyDocumentParsers.kt
@@ -28,10 +28,21 @@ import com.jesuslcorominas.teamflowmanager.domain.model.PlayerTimeStatus
  */
 private fun Map<String, Any?>.asLong(key: String): Long? = (this[key] as? Number)?.toLong()
 
+/**
+ * Reads a boolean Firestore field regardless of the concrete type the platform SDK produced.
+ * iOS/GitLive may surface booleans as NSNumber-backed [Number] (0/1) rather than [Boolean];
+ * a plain `as? Boolean` would then yield null and silently default to false.
+ */
+private fun Map<String, Any?>.asBoolean(key: String): Boolean? =
+    when (val value = this[key]) {
+        is Boolean -> value
+        is Number -> value.toInt() != 0
+        else -> null
+    }
+
 fun parseGoalDocument(
     rawData: Map<String, Any?>?,
     docId: String,
-    teamDocId: String,
     matchId: String,
 ): Goal? {
     if (rawData == null) return null
@@ -42,8 +53,8 @@ fun parseGoalDocument(
             scorerId = rawData["scorerId"]?.toString(),
             goalTimeMillis = rawData.asLong("goalTimeMillis") ?: 0L,
             matchElapsedTimeMillis = rawData.asLong("matchElapsedTimeMillis") ?: 0L,
-            isOpponentGoal = rawData["opponentGoal"] as? Boolean ?: false,
-            isOwnGoal = rawData["ownGoal"] as? Boolean ?: false,
+            isOpponentGoal = rawData.asBoolean("opponentGoal") ?: false,
+            isOwnGoal = rawData.asBoolean("ownGoal") ?: false,
         )
     } catch (_: Exception) {
         null
@@ -53,7 +64,6 @@ fun parseGoalDocument(
 fun parseSubstitutionDocument(
     rawData: Map<String, Any?>?,
     docId: String,
-    teamDocId: String,
     matchId: String,
 ): PlayerSubstitution? {
     if (rawData == null) return null
@@ -73,23 +83,21 @@ fun parseSubstitutionDocument(
 
 fun parsePlayerTimeDocument(
     rawData: Map<String, Any?>?,
-    docId: String,
-    teamDocId: String,
     matchId: String,
 ): PlayerTime? {
     if (rawData == null) return null
     return try {
         val rawPlayerId = rawData["playerId"]?.toString() ?: ""
-        val rawStatus = rawData["status"] as? String ?: PlayerTimeStatus.ON_BENCH.name
+        val rawStatus = rawData["status"] as? String
         PlayerTime(
             playerId = rawPlayerId,
             matchId = matchId,
             elapsedTimeMillis = rawData.asLong("elapsedTimeMillis") ?: 0L,
-            isRunning = rawData["running"] as? Boolean ?: false,
+            isRunning = rawData.asBoolean("running") ?: false,
             lastStartTimeMillis = rawData.asLong("lastStartTimeMillis"),
             status =
                 try {
-                    PlayerTimeStatus.valueOf(rawStatus)
+                    rawStatus?.let { PlayerTimeStatus.valueOf(it) } ?: PlayerTimeStatus.ON_BENCH
                 } catch (_: Exception) {
                     PlayerTimeStatus.ON_BENCH
                 },
@@ -103,7 +111,6 @@ fun parsePlayerTimeDocument(
 fun parsePlayerTimeHistoryDocument(
     rawData: Map<String, Any?>?,
     docId: String,
-    teamDocId: String,
     playerId: String,
     matchId: String,
 ): PlayerTimeHistory? {

--- a/data/remote/src/commonMain/kotlin/com/jesuslcorominas/teamflowmanager/data/remote/firestore/LegacyDocumentParsers.kt
+++ b/data/remote/src/commonMain/kotlin/com/jesuslcorominas/teamflowmanager/data/remote/firestore/LegacyDocumentParsers.kt
@@ -1,0 +1,122 @@
+package com.jesuslcorominas.teamflowmanager.data.remote.firestore
+
+import com.jesuslcorominas.teamflowmanager.domain.model.Goal
+import com.jesuslcorominas.teamflowmanager.domain.model.PlayerSubstitution
+import com.jesuslcorominas.teamflowmanager.domain.model.PlayerTime
+import com.jesuslcorominas.teamflowmanager.domain.model.PlayerTimeHistory
+import com.jesuslcorominas.teamflowmanager.domain.model.PlayerTimeStatus
+
+/*
+ * Pure, platform-agnostic field-by-field parsers for Firestore documents that may still be
+ * stored in the pre-migration (legacy) Long-ID format. kotlinx-serialization / typed
+ * deserialization throws on the whole document when a field's runtime type doesn't match the
+ * declared model (e.g. a legacy `Long` where the model declares `String`), silently dropping the
+ * entire result set. Reading from a raw `Map<String, Any?>` field-by-field tolerates both the
+ * legacy and the current document shapes.
+ *
+ * Shared between the Android (`androidMain`) and iOS (`iosMain`) Firestore datasources so the
+ * parsing logic has a single source of truth (#385.4).
+ *
+ * TODO: remove after backward-compat window closes.
+ */
+
+/**
+ * Reads a numeric Firestore field as [Long] regardless of the concrete [Number] subtype the
+ * platform SDK produced. Android Play-services returns integer fields as [Long], but iOS/GitLive
+ * decoding of a raw `Map<String, Any?>` may surface them as [Int] or [Double]; a plain `as? Long`
+ * would then yield `null` and silently zero the value (this is what kept #384's chart flat).
+ */
+private fun Map<String, Any?>.asLong(key: String): Long? = (this[key] as? Number)?.toLong()
+
+fun parseGoalDocument(
+    rawData: Map<String, Any?>?,
+    docId: String,
+    teamDocId: String,
+    matchId: String,
+): Goal? {
+    if (rawData == null) return null
+    return try {
+        Goal(
+            id = docId,
+            matchId = matchId,
+            scorerId = rawData["scorerId"]?.toString(),
+            goalTimeMillis = rawData.asLong("goalTimeMillis") ?: 0L,
+            matchElapsedTimeMillis = rawData.asLong("matchElapsedTimeMillis") ?: 0L,
+            isOpponentGoal = rawData["opponentGoal"] as? Boolean ?: false,
+            isOwnGoal = rawData["ownGoal"] as? Boolean ?: false,
+        )
+    } catch (_: Exception) {
+        null
+    }
+}
+
+fun parseSubstitutionDocument(
+    rawData: Map<String, Any?>?,
+    docId: String,
+    teamDocId: String,
+    matchId: String,
+): PlayerSubstitution? {
+    if (rawData == null) return null
+    return try {
+        PlayerSubstitution(
+            id = docId,
+            matchId = matchId,
+            playerOutId = rawData["playerOutId"]?.toString() ?: "",
+            playerInId = rawData["playerInId"]?.toString() ?: "",
+            substitutionTimeMillis = rawData.asLong("substitutionTimeMillis") ?: 0L,
+            matchElapsedTimeMillis = rawData.asLong("matchElapsedTimeMillis") ?: 0L,
+        )
+    } catch (_: Exception) {
+        null
+    }
+}
+
+fun parsePlayerTimeDocument(
+    rawData: Map<String, Any?>?,
+    docId: String,
+    teamDocId: String,
+    matchId: String,
+): PlayerTime? {
+    if (rawData == null) return null
+    return try {
+        val rawPlayerId = rawData["playerId"]?.toString() ?: ""
+        val rawStatus = rawData["status"] as? String ?: PlayerTimeStatus.ON_BENCH.name
+        PlayerTime(
+            playerId = rawPlayerId,
+            matchId = matchId,
+            elapsedTimeMillis = rawData.asLong("elapsedTimeMillis") ?: 0L,
+            isRunning = rawData["running"] as? Boolean ?: false,
+            lastStartTimeMillis = rawData.asLong("lastStartTimeMillis"),
+            status =
+                try {
+                    PlayerTimeStatus.valueOf(rawStatus)
+                } catch (_: Exception) {
+                    PlayerTimeStatus.ON_BENCH
+                },
+            lastOperationId = rawData["lastOperationId"] as? String,
+        )
+    } catch (_: Exception) {
+        null
+    }
+}
+
+fun parsePlayerTimeHistoryDocument(
+    rawData: Map<String, Any?>?,
+    docId: String,
+    teamDocId: String,
+    playerId: String,
+    matchId: String,
+): PlayerTimeHistory? {
+    if (rawData == null) return null
+    return try {
+        PlayerTimeHistory(
+            id = docId,
+            playerId = playerId,
+            matchId = matchId,
+            elapsedTimeMillis = rawData.asLong("elapsedTimeMillis") ?: 0L,
+            savedAtMillis = rawData.asLong("savedAtMillis") ?: 0L,
+        )
+    } catch (_: Exception) {
+        null
+    }
+}

--- a/data/remote/src/commonTest/kotlin/com/jesuslcorominas/teamflowmanager/data/remote/firestore/LegacyDocumentParsersTest.kt
+++ b/data/remote/src/commonTest/kotlin/com/jesuslcorominas/teamflowmanager/data/remote/firestore/LegacyDocumentParsersTest.kt
@@ -13,12 +13,12 @@ class LegacyDocumentParsersTest {
 
     @Test
     fun `parseGoalDocument returns null for null map`() {
-        assertNull(parseGoalDocument(null, "doc1", "team1", "match1"))
+        assertNull(parseGoalDocument(null, "doc1", "match1"))
     }
 
     @Test
     fun `parseGoalDocument returns null for empty map`() {
-        val result = parseGoalDocument(emptyMap(), "doc1", "team1", "match1")
+        val result = parseGoalDocument(emptyMap(), "doc1", "match1")
         assertNull(result?.scorerId)
         assertEquals("match1", result?.matchId)
     }
@@ -26,7 +26,7 @@ class LegacyDocumentParsersTest {
     @Test
     fun `parseGoalDocument tolerates legacy Long scorerId and overrides matchId with the passed String`() {
         val rawData = mapOf("scorerId" to 123456789L)
-        val result = parseGoalDocument(rawData, "doc1", "team1", "match-string-id")
+        val result = parseGoalDocument(rawData, "doc1", "match-string-id")
         assertEquals("match-string-id", result?.matchId)
         assertEquals("123456789", result?.scorerId)
     }
@@ -34,14 +34,14 @@ class LegacyDocumentParsersTest {
     @Test
     fun `parseGoalDocument preserves non-zero matchElapsedTimeMillis`() {
         val rawData = mapOf("matchElapsedTimeMillis" to 954000L)
-        val result = parseGoalDocument(rawData, "doc1", "team1", "match1")
+        val result = parseGoalDocument(rawData, "doc1", "match1")
         assertEquals(954000L, result?.matchElapsedTimeMillis)
     }
 
     @Test
     fun `parseGoalDocument does not default matchElapsedTimeMillis to 0 when present`() {
         val rawData = mapOf("matchElapsedTimeMillis" to 42L)
-        val result = parseGoalDocument(rawData, "doc1", "team1", "match1")
+        val result = parseGoalDocument(rawData, "doc1", "match1")
         assertEquals(42L, result?.matchElapsedTimeMillis)
     }
 
@@ -56,7 +56,7 @@ class LegacyDocumentParsersTest {
                 "opponentGoal" to true,
                 "ownGoal" to false,
             )
-        val result = parseGoalDocument(rawData, "doc1", "team1", "match1")
+        val result = parseGoalDocument(rawData, "doc1", "match1")
         assertEquals("doc1", result?.id)
         assertEquals("player-1", result?.scorerId)
         assertEquals(1000L, result?.goalTimeMillis)
@@ -68,36 +68,64 @@ class LegacyDocumentParsersTest {
     @Test
     fun `parseGoalDocument coerces Int goalTimeMillis to Long`() {
         val rawData = mapOf("goalTimeMillis" to 1500)
-        val result = parseGoalDocument(rawData, "doc1", "team1", "match1")
+        val result = parseGoalDocument(rawData, "doc1", "match1")
         assertEquals(1500L, result?.goalTimeMillis)
     }
 
     @Test
     fun `parseGoalDocument coerces Double goalTimeMillis to Long`() {
         val rawData = mapOf("goalTimeMillis" to 1500.0)
-        val result = parseGoalDocument(rawData, "doc1", "team1", "match1")
+        val result = parseGoalDocument(rawData, "doc1", "match1")
         assertEquals(1500L, result?.goalTimeMillis)
     }
 
     @Test
     fun `parseGoalDocument coerces Int matchElapsedTimeMillis to Long`() {
         val rawData = mapOf("matchElapsedTimeMillis" to 1500)
-        val result = parseGoalDocument(rawData, "doc1", "team1", "match1")
+        val result = parseGoalDocument(rawData, "doc1", "match1")
         assertEquals(1500L, result?.matchElapsedTimeMillis)
     }
 
     @Test
     fun `parseGoalDocument coerces Double matchElapsedTimeMillis to Long`() {
         val rawData = mapOf("matchElapsedTimeMillis" to 1500.0)
-        val result = parseGoalDocument(rawData, "doc1", "team1", "match1")
+        val result = parseGoalDocument(rawData, "doc1", "match1")
         assertEquals(1500L, result?.matchElapsedTimeMillis)
     }
 
     @Test
     fun `parseGoalDocument defaults boolean fields when missing`() {
         val rawData = mapOf("scorerId" to "player-1")
-        val result = parseGoalDocument(rawData, "doc1", "team1", "match1")
+        val result = parseGoalDocument(rawData, "doc1", "match1")
         assertFalse(result?.isOpponentGoal == true)
+        assertFalse(result?.isOwnGoal == true)
+    }
+
+    @Test
+    fun `parseGoalDocument coerces Number 1 opponentGoal to true`() {
+        val rawData = mapOf("opponentGoal" to 1L)
+        val result = parseGoalDocument(rawData, "doc1", "match1")
+        assertTrue(result?.isOpponentGoal == true)
+    }
+
+    @Test
+    fun `parseGoalDocument coerces Number 0 opponentGoal to false`() {
+        val rawData = mapOf("opponentGoal" to 0L)
+        val result = parseGoalDocument(rawData, "doc1", "match1")
+        assertFalse(result?.isOpponentGoal == true)
+    }
+
+    @Test
+    fun `parseGoalDocument coerces Number 1 ownGoal to true`() {
+        val rawData = mapOf("ownGoal" to 1L)
+        val result = parseGoalDocument(rawData, "doc1", "match1")
+        assertTrue(result?.isOwnGoal == true)
+    }
+
+    @Test
+    fun `parseGoalDocument coerces Number 0 ownGoal to false`() {
+        val rawData = mapOf("ownGoal" to 0L)
+        val result = parseGoalDocument(rawData, "doc1", "match1")
         assertFalse(result?.isOwnGoal == true)
     }
 
@@ -107,7 +135,7 @@ class LegacyDocumentParsersTest {
 
     @Test
     fun `parseSubstitutionDocument returns null for null map`() {
-        assertNull(parseSubstitutionDocument(null, "doc1", "team1", "match1"))
+        assertNull(parseSubstitutionDocument(null, "doc1", "match1"))
     }
 
     @Test
@@ -119,7 +147,7 @@ class LegacyDocumentParsersTest {
                 "substitutionTimeMillis" to 2000L,
                 "matchElapsedTimeMillis" to 1500L,
             )
-        val result = parseSubstitutionDocument(rawData, "doc1", "team1", "match-string-id")
+        val result = parseSubstitutionDocument(rawData, "doc1", "match-string-id")
         assertEquals("111", result?.playerOutId)
         assertEquals("222", result?.playerInId)
         assertEquals("match-string-id", result?.matchId)
@@ -135,7 +163,7 @@ class LegacyDocumentParsersTest {
                 "substitutionTimeMillis" to 3000L,
                 "matchElapsedTimeMillis" to 2500L,
             )
-        val result = parseSubstitutionDocument(rawData, "doc1", "team1", "match1")
+        val result = parseSubstitutionDocument(rawData, "doc1", "match1")
         assertEquals("doc1", result?.id)
         assertEquals("player-out", result?.playerOutId)
         assertEquals("player-in", result?.playerInId)
@@ -146,34 +174,34 @@ class LegacyDocumentParsersTest {
     @Test
     fun `parseSubstitutionDocument coerces Int substitutionTimeMillis to Long`() {
         val rawData = mapOf("substitutionTimeMillis" to 2000)
-        val result = parseSubstitutionDocument(rawData, "doc1", "team1", "match1")
+        val result = parseSubstitutionDocument(rawData, "doc1", "match1")
         assertEquals(2000L, result?.substitutionTimeMillis)
     }
 
     @Test
     fun `parseSubstitutionDocument coerces Double substitutionTimeMillis to Long`() {
         val rawData = mapOf("substitutionTimeMillis" to 2000.0)
-        val result = parseSubstitutionDocument(rawData, "doc1", "team1", "match1")
+        val result = parseSubstitutionDocument(rawData, "doc1", "match1")
         assertEquals(2000L, result?.substitutionTimeMillis)
     }
 
     @Test
     fun `parseSubstitutionDocument coerces Int matchElapsedTimeMillis to Long`() {
         val rawData = mapOf("matchElapsedTimeMillis" to 1500)
-        val result = parseSubstitutionDocument(rawData, "doc1", "team1", "match1")
+        val result = parseSubstitutionDocument(rawData, "doc1", "match1")
         assertEquals(1500L, result?.matchElapsedTimeMillis)
     }
 
     @Test
     fun `parseSubstitutionDocument coerces Double matchElapsedTimeMillis to Long`() {
         val rawData = mapOf("matchElapsedTimeMillis" to 1500.0)
-        val result = parseSubstitutionDocument(rawData, "doc1", "team1", "match1")
+        val result = parseSubstitutionDocument(rawData, "doc1", "match1")
         assertEquals(1500L, result?.matchElapsedTimeMillis)
     }
 
     @Test
     fun `parseSubstitutionDocument defaults empty cross-ref fields to empty string`() {
-        val result = parseSubstitutionDocument(emptyMap(), "doc1", "team1", "match1")
+        val result = parseSubstitutionDocument(emptyMap(), "doc1", "match1")
         assertEquals("", result?.playerOutId)
         assertEquals("", result?.playerInId)
     }
@@ -184,19 +212,19 @@ class LegacyDocumentParsersTest {
 
     @Test
     fun `parsePlayerTimeDocument returns null for null map`() {
-        assertNull(parsePlayerTimeDocument(null, "doc1", "team1", "match1"))
+        assertNull(parsePlayerTimeDocument(null, "match1"))
     }
 
     @Test
     fun `parsePlayerTimeDocument tolerates legacy Long playerId`() {
         val rawData = mapOf("playerId" to 999L)
-        val result = parsePlayerTimeDocument(rawData, "doc1", "team1", "match1")
+        val result = parsePlayerTimeDocument(rawData, "match1")
         assertEquals("999", result?.playerId)
     }
 
     @Test
     fun `parsePlayerTimeDocument defaults status to ON_BENCH when missing`() {
-        val result = parsePlayerTimeDocument(emptyMap(), "doc1", "team1", "match1")
+        val result = parsePlayerTimeDocument(emptyMap(), "match1")
         assertEquals(PlayerTimeStatus.ON_BENCH, result?.status)
     }
 
@@ -211,7 +239,7 @@ class LegacyDocumentParsersTest {
                 "status" to "PLAYING",
                 "lastOperationId" to "op-1",
             )
-        val result = parsePlayerTimeDocument(rawData, "doc1", "team1", "match1")
+        val result = parsePlayerTimeDocument(rawData, "match1")
         assertEquals("player-1", result?.playerId)
         assertEquals(12000L, result?.elapsedTimeMillis)
         assertTrue(result?.isRunning == true)
@@ -223,47 +251,61 @@ class LegacyDocumentParsersTest {
     @Test
     fun `parsePlayerTimeDocument coerces Int elapsedTimeMillis to Long`() {
         val rawData = mapOf("elapsedTimeMillis" to 12000)
-        val result = parsePlayerTimeDocument(rawData, "doc1", "team1", "match1")
+        val result = parsePlayerTimeDocument(rawData, "match1")
         assertEquals(12000L, result?.elapsedTimeMillis)
     }
 
     @Test
     fun `parsePlayerTimeDocument coerces Double elapsedTimeMillis to Long`() {
         val rawData = mapOf("elapsedTimeMillis" to 12000.0)
-        val result = parsePlayerTimeDocument(rawData, "doc1", "team1", "match1")
+        val result = parsePlayerTimeDocument(rawData, "match1")
         assertEquals(12000L, result?.elapsedTimeMillis)
     }
 
     @Test
     fun `parsePlayerTimeDocument coerces Int lastStartTimeMillis to Long`() {
         val rawData = mapOf("lastStartTimeMillis" to 5000)
-        val result = parsePlayerTimeDocument(rawData, "doc1", "team1", "match1")
+        val result = parsePlayerTimeDocument(rawData, "match1")
         assertEquals(5000L, result?.lastStartTimeMillis)
     }
 
     @Test
     fun `parsePlayerTimeDocument coerces Double lastStartTimeMillis to Long`() {
         val rawData = mapOf("lastStartTimeMillis" to 5000.0)
-        val result = parsePlayerTimeDocument(rawData, "doc1", "team1", "match1")
+        val result = parsePlayerTimeDocument(rawData, "match1")
         assertEquals(5000L, result?.lastStartTimeMillis)
     }
 
     @Test
     fun `parsePlayerTimeDocument defaults running to false when missing`() {
-        val result = parsePlayerTimeDocument(emptyMap(), "doc1", "team1", "match1")
+        val result = parsePlayerTimeDocument(emptyMap(), "match1")
+        assertFalse(result?.isRunning == true)
+    }
+
+    @Test
+    fun `parsePlayerTimeDocument coerces Number 1 running to true`() {
+        val rawData = mapOf("running" to 1L)
+        val result = parsePlayerTimeDocument(rawData, "match1")
+        assertTrue(result?.isRunning == true)
+    }
+
+    @Test
+    fun `parsePlayerTimeDocument coerces Number 0 running to false`() {
+        val rawData = mapOf("running" to 0L)
+        val result = parsePlayerTimeDocument(rawData, "match1")
         assertFalse(result?.isRunning == true)
     }
 
     @Test
     fun `parsePlayerTimeDocument defaults invalid status to ON_BENCH`() {
         val rawData = mapOf("status" to "INVALID_STATUS")
-        val result = parsePlayerTimeDocument(rawData, "doc1", "team1", "match1")
+        val result = parsePlayerTimeDocument(rawData, "match1")
         assertEquals(PlayerTimeStatus.ON_BENCH, result?.status)
     }
 
     @Test
     fun `parsePlayerTimeDocument defaults all fields for empty map`() {
-        val result = parsePlayerTimeDocument(emptyMap(), "doc1", "team1", "match1")
+        val result = parsePlayerTimeDocument(emptyMap(), "match1")
         assertEquals("", result?.playerId)
         assertEquals(0L, result?.elapsedTimeMillis)
         assertFalse(result?.isRunning == true)
@@ -278,7 +320,7 @@ class LegacyDocumentParsersTest {
 
     @Test
     fun `parsePlayerTimeHistoryDocument returns null for null map`() {
-        assertNull(parsePlayerTimeHistoryDocument(null, "doc1", "team1", "player1", "match1"))
+        assertNull(parsePlayerTimeHistoryDocument(null, "doc1", "player1", "match1"))
     }
 
     @Test
@@ -288,7 +330,7 @@ class LegacyDocumentParsersTest {
                 "elapsedTimeMillis" to 7000L,
                 "savedAtMillis" to 8000L,
             )
-        val result = parsePlayerTimeHistoryDocument(rawData, "doc1", "team1", "player1", "match1")
+        val result = parsePlayerTimeHistoryDocument(rawData, "doc1", "player1", "match1")
         assertEquals("doc1", result?.id)
         assertEquals("player1", result?.playerId)
         assertEquals("match1", result?.matchId)
@@ -298,7 +340,7 @@ class LegacyDocumentParsersTest {
 
     @Test
     fun `parsePlayerTimeHistoryDocument tolerates missing numeric fields with 0 defaults`() {
-        val result = parsePlayerTimeHistoryDocument(emptyMap(), "doc1", "team1", "player1", "match1")
+        val result = parsePlayerTimeHistoryDocument(emptyMap(), "doc1", "player1", "match1")
         assertEquals(0L, result?.elapsedTimeMillis)
         assertEquals(0L, result?.savedAtMillis)
     }
@@ -306,28 +348,28 @@ class LegacyDocumentParsersTest {
     @Test
     fun `parsePlayerTimeHistoryDocument coerces Int elapsedTimeMillis to Long`() {
         val rawData = mapOf("elapsedTimeMillis" to 7000)
-        val result = parsePlayerTimeHistoryDocument(rawData, "doc1", "team1", "player1", "match1")
+        val result = parsePlayerTimeHistoryDocument(rawData, "doc1", "player1", "match1")
         assertEquals(7000L, result?.elapsedTimeMillis)
     }
 
     @Test
     fun `parsePlayerTimeHistoryDocument coerces Double elapsedTimeMillis to Long`() {
         val rawData = mapOf("elapsedTimeMillis" to 7000.0)
-        val result = parsePlayerTimeHistoryDocument(rawData, "doc1", "team1", "player1", "match1")
+        val result = parsePlayerTimeHistoryDocument(rawData, "doc1", "player1", "match1")
         assertEquals(7000L, result?.elapsedTimeMillis)
     }
 
     @Test
     fun `parsePlayerTimeHistoryDocument coerces Int savedAtMillis to Long`() {
         val rawData = mapOf("savedAtMillis" to 8000)
-        val result = parsePlayerTimeHistoryDocument(rawData, "doc1", "team1", "player1", "match1")
+        val result = parsePlayerTimeHistoryDocument(rawData, "doc1", "player1", "match1")
         assertEquals(8000L, result?.savedAtMillis)
     }
 
     @Test
     fun `parsePlayerTimeHistoryDocument coerces Double savedAtMillis to Long`() {
         val rawData = mapOf("savedAtMillis" to 8000.0)
-        val result = parsePlayerTimeHistoryDocument(rawData, "doc1", "team1", "player1", "match1")
+        val result = parsePlayerTimeHistoryDocument(rawData, "doc1", "player1", "match1")
         assertEquals(8000L, result?.savedAtMillis)
     }
 

--- a/data/remote/src/commonTest/kotlin/com/jesuslcorominas/teamflowmanager/data/remote/firestore/LegacyDocumentParsersTest.kt
+++ b/data/remote/src/commonTest/kotlin/com/jesuslcorominas/teamflowmanager/data/remote/firestore/LegacyDocumentParsersTest.kt
@@ -1,0 +1,335 @@
+package com.jesuslcorominas.teamflowmanager.data.remote.firestore
+
+import com.jesuslcorominas.teamflowmanager.domain.model.PlayerTimeStatus
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class LegacyDocumentParsersTest {
+
+    // region parseGoalDocument
+
+    @Test
+    fun `parseGoalDocument returns null for null map`() {
+        assertNull(parseGoalDocument(null, "doc1", "team1", "match1"))
+    }
+
+    @Test
+    fun `parseGoalDocument returns null for empty map`() {
+        val result = parseGoalDocument(emptyMap(), "doc1", "team1", "match1")
+        assertNull(result?.scorerId)
+        assertEquals("match1", result?.matchId)
+    }
+
+    @Test
+    fun `parseGoalDocument tolerates legacy Long scorerId and overrides matchId with the passed String`() {
+        val rawData = mapOf("scorerId" to 123456789L)
+        val result = parseGoalDocument(rawData, "doc1", "team1", "match-string-id")
+        assertEquals("match-string-id", result?.matchId)
+        assertEquals("123456789", result?.scorerId)
+    }
+
+    @Test
+    fun `parseGoalDocument preserves non-zero matchElapsedTimeMillis`() {
+        val rawData = mapOf("matchElapsedTimeMillis" to 954000L)
+        val result = parseGoalDocument(rawData, "doc1", "team1", "match1")
+        assertEquals(954000L, result?.matchElapsedTimeMillis)
+    }
+
+    @Test
+    fun `parseGoalDocument does not default matchElapsedTimeMillis to 0 when present`() {
+        val rawData = mapOf("matchElapsedTimeMillis" to 42L)
+        val result = parseGoalDocument(rawData, "doc1", "team1", "match1")
+        assertEquals(42L, result?.matchElapsedTimeMillis)
+    }
+
+    @Test
+    fun `parseGoalDocument new-format map maps all fields correctly`() {
+        val rawData =
+            mapOf(
+                "teamId" to "team1",
+                "scorerId" to "player-1",
+                "goalTimeMillis" to 1000L,
+                "matchElapsedTimeMillis" to 500L,
+                "opponentGoal" to true,
+                "ownGoal" to false,
+            )
+        val result = parseGoalDocument(rawData, "doc1", "team1", "match1")
+        assertEquals("doc1", result?.id)
+        assertEquals("player-1", result?.scorerId)
+        assertEquals(1000L, result?.goalTimeMillis)
+        assertEquals(500L, result?.matchElapsedTimeMillis)
+        assertTrue(result?.isOpponentGoal == true)
+        assertFalse(result?.isOwnGoal == true)
+    }
+
+    @Test
+    fun `parseGoalDocument coerces Int goalTimeMillis to Long`() {
+        val rawData = mapOf("goalTimeMillis" to 1500)
+        val result = parseGoalDocument(rawData, "doc1", "team1", "match1")
+        assertEquals(1500L, result?.goalTimeMillis)
+    }
+
+    @Test
+    fun `parseGoalDocument coerces Double goalTimeMillis to Long`() {
+        val rawData = mapOf("goalTimeMillis" to 1500.0)
+        val result = parseGoalDocument(rawData, "doc1", "team1", "match1")
+        assertEquals(1500L, result?.goalTimeMillis)
+    }
+
+    @Test
+    fun `parseGoalDocument coerces Int matchElapsedTimeMillis to Long`() {
+        val rawData = mapOf("matchElapsedTimeMillis" to 1500)
+        val result = parseGoalDocument(rawData, "doc1", "team1", "match1")
+        assertEquals(1500L, result?.matchElapsedTimeMillis)
+    }
+
+    @Test
+    fun `parseGoalDocument coerces Double matchElapsedTimeMillis to Long`() {
+        val rawData = mapOf("matchElapsedTimeMillis" to 1500.0)
+        val result = parseGoalDocument(rawData, "doc1", "team1", "match1")
+        assertEquals(1500L, result?.matchElapsedTimeMillis)
+    }
+
+    @Test
+    fun `parseGoalDocument defaults boolean fields when missing`() {
+        val rawData = mapOf("scorerId" to "player-1")
+        val result = parseGoalDocument(rawData, "doc1", "team1", "match1")
+        assertFalse(result?.isOpponentGoal == true)
+        assertFalse(result?.isOwnGoal == true)
+    }
+
+    // endregion
+
+    // region parseSubstitutionDocument
+
+    @Test
+    fun `parseSubstitutionDocument returns null for null map`() {
+        assertNull(parseSubstitutionDocument(null, "doc1", "team1", "match1"))
+    }
+
+    @Test
+    fun `parseSubstitutionDocument tolerates legacy Long cross-ref fields`() {
+        val rawData =
+            mapOf(
+                "playerOutId" to 111L,
+                "playerInId" to 222L,
+                "substitutionTimeMillis" to 2000L,
+                "matchElapsedTimeMillis" to 1500L,
+            )
+        val result = parseSubstitutionDocument(rawData, "doc1", "team1", "match-string-id")
+        assertEquals("111", result?.playerOutId)
+        assertEquals("222", result?.playerInId)
+        assertEquals("match-string-id", result?.matchId)
+        assertEquals(1500L, result?.matchElapsedTimeMillis)
+    }
+
+    @Test
+    fun `parseSubstitutionDocument new-format map maps all fields correctly`() {
+        val rawData =
+            mapOf(
+                "playerOutId" to "player-out",
+                "playerInId" to "player-in",
+                "substitutionTimeMillis" to 3000L,
+                "matchElapsedTimeMillis" to 2500L,
+            )
+        val result = parseSubstitutionDocument(rawData, "doc1", "team1", "match1")
+        assertEquals("doc1", result?.id)
+        assertEquals("player-out", result?.playerOutId)
+        assertEquals("player-in", result?.playerInId)
+        assertEquals(3000L, result?.substitutionTimeMillis)
+        assertEquals(2500L, result?.matchElapsedTimeMillis)
+    }
+
+    @Test
+    fun `parseSubstitutionDocument coerces Int substitutionTimeMillis to Long`() {
+        val rawData = mapOf("substitutionTimeMillis" to 2000)
+        val result = parseSubstitutionDocument(rawData, "doc1", "team1", "match1")
+        assertEquals(2000L, result?.substitutionTimeMillis)
+    }
+
+    @Test
+    fun `parseSubstitutionDocument coerces Double substitutionTimeMillis to Long`() {
+        val rawData = mapOf("substitutionTimeMillis" to 2000.0)
+        val result = parseSubstitutionDocument(rawData, "doc1", "team1", "match1")
+        assertEquals(2000L, result?.substitutionTimeMillis)
+    }
+
+    @Test
+    fun `parseSubstitutionDocument coerces Int matchElapsedTimeMillis to Long`() {
+        val rawData = mapOf("matchElapsedTimeMillis" to 1500)
+        val result = parseSubstitutionDocument(rawData, "doc1", "team1", "match1")
+        assertEquals(1500L, result?.matchElapsedTimeMillis)
+    }
+
+    @Test
+    fun `parseSubstitutionDocument coerces Double matchElapsedTimeMillis to Long`() {
+        val rawData = mapOf("matchElapsedTimeMillis" to 1500.0)
+        val result = parseSubstitutionDocument(rawData, "doc1", "team1", "match1")
+        assertEquals(1500L, result?.matchElapsedTimeMillis)
+    }
+
+    @Test
+    fun `parseSubstitutionDocument defaults empty cross-ref fields to empty string`() {
+        val result = parseSubstitutionDocument(emptyMap(), "doc1", "team1", "match1")
+        assertEquals("", result?.playerOutId)
+        assertEquals("", result?.playerInId)
+    }
+
+    // endregion
+
+    // region parsePlayerTimeDocument
+
+    @Test
+    fun `parsePlayerTimeDocument returns null for null map`() {
+        assertNull(parsePlayerTimeDocument(null, "doc1", "team1", "match1"))
+    }
+
+    @Test
+    fun `parsePlayerTimeDocument tolerates legacy Long playerId`() {
+        val rawData = mapOf("playerId" to 999L)
+        val result = parsePlayerTimeDocument(rawData, "doc1", "team1", "match1")
+        assertEquals("999", result?.playerId)
+    }
+
+    @Test
+    fun `parsePlayerTimeDocument defaults status to ON_BENCH when missing`() {
+        val result = parsePlayerTimeDocument(emptyMap(), "doc1", "team1", "match1")
+        assertEquals(PlayerTimeStatus.ON_BENCH, result?.status)
+    }
+
+    @Test
+    fun `parsePlayerTimeDocument new-format map maps all fields correctly`() {
+        val rawData =
+            mapOf(
+                "playerId" to "player-1",
+                "elapsedTimeMillis" to 12000L,
+                "running" to true,
+                "lastStartTimeMillis" to 5000L,
+                "status" to "PLAYING",
+                "lastOperationId" to "op-1",
+            )
+        val result = parsePlayerTimeDocument(rawData, "doc1", "team1", "match1")
+        assertEquals("player-1", result?.playerId)
+        assertEquals(12000L, result?.elapsedTimeMillis)
+        assertTrue(result?.isRunning == true)
+        assertEquals(5000L, result?.lastStartTimeMillis)
+        assertEquals(PlayerTimeStatus.PLAYING, result?.status)
+        assertEquals("op-1", result?.lastOperationId)
+    }
+
+    @Test
+    fun `parsePlayerTimeDocument coerces Int elapsedTimeMillis to Long`() {
+        val rawData = mapOf("elapsedTimeMillis" to 12000)
+        val result = parsePlayerTimeDocument(rawData, "doc1", "team1", "match1")
+        assertEquals(12000L, result?.elapsedTimeMillis)
+    }
+
+    @Test
+    fun `parsePlayerTimeDocument coerces Double elapsedTimeMillis to Long`() {
+        val rawData = mapOf("elapsedTimeMillis" to 12000.0)
+        val result = parsePlayerTimeDocument(rawData, "doc1", "team1", "match1")
+        assertEquals(12000L, result?.elapsedTimeMillis)
+    }
+
+    @Test
+    fun `parsePlayerTimeDocument coerces Int lastStartTimeMillis to Long`() {
+        val rawData = mapOf("lastStartTimeMillis" to 5000)
+        val result = parsePlayerTimeDocument(rawData, "doc1", "team1", "match1")
+        assertEquals(5000L, result?.lastStartTimeMillis)
+    }
+
+    @Test
+    fun `parsePlayerTimeDocument coerces Double lastStartTimeMillis to Long`() {
+        val rawData = mapOf("lastStartTimeMillis" to 5000.0)
+        val result = parsePlayerTimeDocument(rawData, "doc1", "team1", "match1")
+        assertEquals(5000L, result?.lastStartTimeMillis)
+    }
+
+    @Test
+    fun `parsePlayerTimeDocument defaults running to false when missing`() {
+        val result = parsePlayerTimeDocument(emptyMap(), "doc1", "team1", "match1")
+        assertFalse(result?.isRunning == true)
+    }
+
+    @Test
+    fun `parsePlayerTimeDocument defaults invalid status to ON_BENCH`() {
+        val rawData = mapOf("status" to "INVALID_STATUS")
+        val result = parsePlayerTimeDocument(rawData, "doc1", "team1", "match1")
+        assertEquals(PlayerTimeStatus.ON_BENCH, result?.status)
+    }
+
+    @Test
+    fun `parsePlayerTimeDocument defaults all fields for empty map`() {
+        val result = parsePlayerTimeDocument(emptyMap(), "doc1", "team1", "match1")
+        assertEquals("", result?.playerId)
+        assertEquals(0L, result?.elapsedTimeMillis)
+        assertFalse(result?.isRunning == true)
+        assertEquals(null, result?.lastStartTimeMillis)
+        assertEquals(PlayerTimeStatus.ON_BENCH, result?.status)
+        assertEquals(null, result?.lastOperationId)
+    }
+
+    // endregion
+
+    // region parsePlayerTimeHistoryDocument
+
+    @Test
+    fun `parsePlayerTimeHistoryDocument returns null for null map`() {
+        assertNull(parsePlayerTimeHistoryDocument(null, "doc1", "team1", "player1", "match1"))
+    }
+
+    @Test
+    fun `parsePlayerTimeHistoryDocument new-format map maps all fields correctly`() {
+        val rawData =
+            mapOf(
+                "elapsedTimeMillis" to 7000L,
+                "savedAtMillis" to 8000L,
+            )
+        val result = parsePlayerTimeHistoryDocument(rawData, "doc1", "team1", "player1", "match1")
+        assertEquals("doc1", result?.id)
+        assertEquals("player1", result?.playerId)
+        assertEquals("match1", result?.matchId)
+        assertEquals(7000L, result?.elapsedTimeMillis)
+        assertEquals(8000L, result?.savedAtMillis)
+    }
+
+    @Test
+    fun `parsePlayerTimeHistoryDocument tolerates missing numeric fields with 0 defaults`() {
+        val result = parsePlayerTimeHistoryDocument(emptyMap(), "doc1", "team1", "player1", "match1")
+        assertEquals(0L, result?.elapsedTimeMillis)
+        assertEquals(0L, result?.savedAtMillis)
+    }
+
+    @Test
+    fun `parsePlayerTimeHistoryDocument coerces Int elapsedTimeMillis to Long`() {
+        val rawData = mapOf("elapsedTimeMillis" to 7000)
+        val result = parsePlayerTimeHistoryDocument(rawData, "doc1", "team1", "player1", "match1")
+        assertEquals(7000L, result?.elapsedTimeMillis)
+    }
+
+    @Test
+    fun `parsePlayerTimeHistoryDocument coerces Double elapsedTimeMillis to Long`() {
+        val rawData = mapOf("elapsedTimeMillis" to 7000.0)
+        val result = parsePlayerTimeHistoryDocument(rawData, "doc1", "team1", "player1", "match1")
+        assertEquals(7000L, result?.elapsedTimeMillis)
+    }
+
+    @Test
+    fun `parsePlayerTimeHistoryDocument coerces Int savedAtMillis to Long`() {
+        val rawData = mapOf("savedAtMillis" to 8000)
+        val result = parsePlayerTimeHistoryDocument(rawData, "doc1", "team1", "player1", "match1")
+        assertEquals(8000L, result?.savedAtMillis)
+    }
+
+    @Test
+    fun `parsePlayerTimeHistoryDocument coerces Double savedAtMillis to Long`() {
+        val rawData = mapOf("savedAtMillis" to 8000.0)
+        val result = parsePlayerTimeHistoryDocument(rawData, "doc1", "team1", "player1", "match1")
+        assertEquals(8000L, result?.savedAtMillis)
+    }
+
+    // endregion
+}

--- a/data/remote/src/iosMain/kotlin/com/jesuslcorominas/teamflowmanager/data/remote/datasource/GoalFirestoreDataSourceImpl.kt
+++ b/data/remote/src/iosMain/kotlin/com/jesuslcorominas/teamflowmanager/data/remote/datasource/GoalFirestoreDataSourceImpl.kt
@@ -1,8 +1,7 @@
 package com.jesuslcorominas.teamflowmanager.data.remote.datasource
 
 import com.jesuslcorominas.teamflowmanager.data.core.datasource.GoalDataSource
-import com.jesuslcorominas.teamflowmanager.data.remote.firestore.GoalFirestoreModel
-import com.jesuslcorominas.teamflowmanager.data.remote.firestore.toDomain
+import com.jesuslcorominas.teamflowmanager.data.remote.firestore.parseGoalDocument
 import com.jesuslcorominas.teamflowmanager.data.remote.firestore.toFirestoreModel
 import com.jesuslcorominas.teamflowmanager.data.remote.util.toLegacyId
 import com.jesuslcorominas.teamflowmanager.domain.model.Goal
@@ -72,42 +71,35 @@ class GoalFirestoreDataSourceImpl(
                 return@flow
             }
             // Combine two real-time listeners: one for new String-ID docs, one for legacy Long-ID docs.
+            // Each source is mapped to a List and given its own .catch BEFORE the combine, so a
+            // failure on the legacy query (e.g. missing composite index) does not blank out
+            // valid new-doc data (#385.3).
             // TODO: remove legacy branch after backward-compat window closes.
-            val newSnapshots =
+            val newGoals =
                 firestore.collection(GOALS_COLLECTION)
                     .where { "teamId" equalTo teamDocId }
                     .where { "matchId" equalTo matchId }
                     .snapshots
-            val legacySnapshots =
+                    .map { qs ->
+                        qs.documents.mapNotNull { doc ->
+                            parseGoalDocument(doc.data<Map<String, Any?>>(), doc.id, teamDocId, matchId)
+                        }
+                    }.catch { e ->
+                        if (e is FirebaseFirestoreException) emit(emptyList()) else throw e
+                    }
+            val legacyGoals =
                 firestore.collection(GOALS_COLLECTION)
                     .where { "teamId" equalTo teamDocId }
                     .where { "matchId" equalTo matchId.toLegacyId() }
                     .snapshots
-            emitAll(
-                combine(newSnapshots, legacySnapshots) { newQs, legacyQs ->
-                    val newGoals =
-                        newQs.documents.mapNotNull { doc ->
-                            try {
-                                doc.data<GoalFirestoreModel>().copy(id = doc.id, matchId = matchId)
-                                    .toDomain()
-                            } catch (_: Exception) {
-                                null
-                            }
+                    .map { qs ->
+                        qs.documents.mapNotNull { doc ->
+                            parseGoalDocument(doc.data<Map<String, Any?>>(), doc.id, teamDocId, matchId)
                         }
-                    val legacyGoals =
-                        legacyQs.documents.mapNotNull { doc ->
-                            try {
-                                doc.data<GoalFirestoreModel>().copy(id = doc.id, matchId = matchId)
-                                    .toDomain()
-                            } catch (_: Exception) {
-                                null
-                            }
-                        }
-                    newGoals + legacyGoals
-                }.catch { e ->
-                    if (e is FirebaseFirestoreException) emit(emptyList()) else throw e
-                },
-            )
+                    }.catch { e ->
+                        if (e is FirebaseFirestoreException) emit(emptyList()) else throw e
+                    }
+            emitAll(combine(newGoals, legacyGoals) { a, b -> a + b })
         }
 
     override fun getAllTeamGoals(): Flow<List<Goal>> =
@@ -129,11 +121,9 @@ class GoalFirestoreDataSourceImpl(
             emitAll(
                 snapshots.map { qs ->
                     qs.documents.mapNotNull { doc ->
-                        try {
-                            doc.data<GoalFirestoreModel>().copy(id = doc.id).toDomain()
-                        } catch (_: Exception) {
-                            null
-                        }
+                        val rawData = doc.data<Map<String, Any?>>()
+                        val rawMatchId = rawData["matchId"]?.toString() ?: ""
+                        parseGoalDocument(rawData, doc.id, teamDocId, rawMatchId)
                     }
                 }.catch { e ->
                     if (e is FirebaseFirestoreException) emit(emptyList()) else throw e

--- a/data/remote/src/iosMain/kotlin/com/jesuslcorominas/teamflowmanager/data/remote/datasource/GoalFirestoreDataSourceImpl.kt
+++ b/data/remote/src/iosMain/kotlin/com/jesuslcorominas/teamflowmanager/data/remote/datasource/GoalFirestoreDataSourceImpl.kt
@@ -82,7 +82,11 @@ class GoalFirestoreDataSourceImpl(
                     .snapshots
                     .map { qs ->
                         qs.documents.mapNotNull { doc ->
-                            parseGoalDocument(doc.data<Map<String, Any?>>(), doc.id, teamDocId, matchId)
+                            try {
+                                parseGoalDocument(doc.data<Map<String, Any?>>(), doc.id, matchId)
+                            } catch (_: Exception) {
+                                null
+                            }
                         }
                     }.catch { e ->
                         if (e is FirebaseFirestoreException) emit(emptyList()) else throw e
@@ -94,7 +98,11 @@ class GoalFirestoreDataSourceImpl(
                     .snapshots
                     .map { qs ->
                         qs.documents.mapNotNull { doc ->
-                            parseGoalDocument(doc.data<Map<String, Any?>>(), doc.id, teamDocId, matchId)
+                            try {
+                                parseGoalDocument(doc.data<Map<String, Any?>>(), doc.id, matchId)
+                            } catch (_: Exception) {
+                                null
+                            }
                         }
                     }.catch { e ->
                         if (e is FirebaseFirestoreException) emit(emptyList()) else throw e
@@ -121,9 +129,13 @@ class GoalFirestoreDataSourceImpl(
             emitAll(
                 snapshots.map { qs ->
                     qs.documents.mapNotNull { doc ->
-                        val rawData = doc.data<Map<String, Any?>>()
-                        val rawMatchId = rawData["matchId"]?.toString() ?: ""
-                        parseGoalDocument(rawData, doc.id, teamDocId, rawMatchId)
+                        try {
+                            val rawData = doc.data<Map<String, Any?>>()
+                            val rawMatchId = rawData["matchId"]?.toString() ?: ""
+                            parseGoalDocument(rawData, doc.id, rawMatchId)
+                        } catch (_: Exception) {
+                            null
+                        }
                     }
                 }.catch { e ->
                     if (e is FirebaseFirestoreException) emit(emptyList()) else throw e

--- a/data/remote/src/iosMain/kotlin/com/jesuslcorominas/teamflowmanager/data/remote/datasource/PlayerSubstitutionFirestoreDataSourceImpl.kt
+++ b/data/remote/src/iosMain/kotlin/com/jesuslcorominas/teamflowmanager/data/remote/datasource/PlayerSubstitutionFirestoreDataSourceImpl.kt
@@ -1,8 +1,7 @@
 package com.jesuslcorominas.teamflowmanager.data.remote.datasource
 
 import com.jesuslcorominas.teamflowmanager.data.core.datasource.PlayerSubstitutionDataSource
-import com.jesuslcorominas.teamflowmanager.data.remote.firestore.PlayerSubstitutionFirestoreModel
-import com.jesuslcorominas.teamflowmanager.data.remote.firestore.toDomain
+import com.jesuslcorominas.teamflowmanager.data.remote.firestore.parseSubstitutionDocument
 import com.jesuslcorominas.teamflowmanager.data.remote.firestore.toFirestoreModel
 import com.jesuslcorominas.teamflowmanager.data.remote.util.toLegacyId
 import com.jesuslcorominas.teamflowmanager.domain.model.PlayerSubstitution
@@ -15,6 +14,7 @@ import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.emitAll
 import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.map
 import kotlin.coroutines.cancellation.CancellationException
 
 class PlayerSubstitutionFirestoreDataSourceImpl(
@@ -71,44 +71,34 @@ class PlayerSubstitutionFirestoreDataSourceImpl(
                 return@flow
             }
             // Combine two real-time listeners: one for new String-ID docs, one for legacy Long-ID docs.
+            // Each source is mapped to a List and given its own .catch BEFORE the combine, so a
+            // failure on the legacy query does not blank out valid new-doc data (#385.3).
             // TODO: remove legacy branch after backward-compat window closes.
-            val newSnapshots =
+            val newSubs =
                 firestore.collection(SUBSTITUTIONS_COLLECTION)
                     .where { "teamId" equalTo teamDocId }
                     .where { "matchId" equalTo matchId }
                     .snapshots
-            val legacySnapshots =
+                    .map { qs ->
+                        qs.documents.mapNotNull { doc ->
+                            parseSubstitutionDocument(doc.data<Map<String, Any?>>(), doc.id, teamDocId, matchId)
+                        }
+                    }.catch { e ->
+                        if (e is FirebaseFirestoreException) emit(emptyList()) else throw e
+                    }
+            val legacySubs =
                 firestore.collection(SUBSTITUTIONS_COLLECTION)
                     .where { "teamId" equalTo teamDocId }
                     .where { "matchId" equalTo matchId.toLegacyId() }
                     .snapshots
-            emitAll(
-                combine(newSnapshots, legacySnapshots) { newQs, legacyQs ->
-                    val newSubs =
-                        newQs.documents.mapNotNull { doc ->
-                            try {
-                                doc.data<PlayerSubstitutionFirestoreModel>()
-                                    .copy(id = doc.id, matchId = matchId)
-                                    .toDomain()
-                            } catch (_: Exception) {
-                                null
-                            }
+                    .map { qs ->
+                        qs.documents.mapNotNull { doc ->
+                            parseSubstitutionDocument(doc.data<Map<String, Any?>>(), doc.id, teamDocId, matchId)
                         }
-                    val legacySubs =
-                        legacyQs.documents.mapNotNull { doc ->
-                            try {
-                                doc.data<PlayerSubstitutionFirestoreModel>()
-                                    .copy(id = doc.id, matchId = matchId)
-                                    .toDomain()
-                            } catch (_: Exception) {
-                                null
-                            }
-                        }
-                    newSubs + legacySubs
-                }.catch { e ->
-                    if (e is FirebaseFirestoreException) emit(emptyList()) else throw e
-                },
-            )
+                    }.catch { e ->
+                        if (e is FirebaseFirestoreException) emit(emptyList()) else throw e
+                    }
+            emitAll(combine(newSubs, legacySubs) { a, b -> a + b })
         }
 
     override suspend fun insertSubstitution(substitution: PlayerSubstitution): String {

--- a/data/remote/src/iosMain/kotlin/com/jesuslcorominas/teamflowmanager/data/remote/datasource/PlayerSubstitutionFirestoreDataSourceImpl.kt
+++ b/data/remote/src/iosMain/kotlin/com/jesuslcorominas/teamflowmanager/data/remote/datasource/PlayerSubstitutionFirestoreDataSourceImpl.kt
@@ -81,7 +81,11 @@ class PlayerSubstitutionFirestoreDataSourceImpl(
                     .snapshots
                     .map { qs ->
                         qs.documents.mapNotNull { doc ->
-                            parseSubstitutionDocument(doc.data<Map<String, Any?>>(), doc.id, teamDocId, matchId)
+                            try {
+                                parseSubstitutionDocument(doc.data<Map<String, Any?>>(), doc.id, matchId)
+                            } catch (_: Exception) {
+                                null
+                            }
                         }
                     }.catch { e ->
                         if (e is FirebaseFirestoreException) emit(emptyList()) else throw e
@@ -93,7 +97,11 @@ class PlayerSubstitutionFirestoreDataSourceImpl(
                     .snapshots
                     .map { qs ->
                         qs.documents.mapNotNull { doc ->
-                            parseSubstitutionDocument(doc.data<Map<String, Any?>>(), doc.id, teamDocId, matchId)
+                            try {
+                                parseSubstitutionDocument(doc.data<Map<String, Any?>>(), doc.id, matchId)
+                            } catch (_: Exception) {
+                                null
+                            }
                         }
                     }.catch { e ->
                         if (e is FirebaseFirestoreException) emit(emptyList()) else throw e

--- a/data/remote/src/iosMain/kotlin/com/jesuslcorominas/teamflowmanager/data/remote/datasource/PlayerTimeFirestoreDataSourceImpl.kt
+++ b/data/remote/src/iosMain/kotlin/com/jesuslcorominas/teamflowmanager/data/remote/datasource/PlayerTimeFirestoreDataSourceImpl.kt
@@ -122,7 +122,11 @@ class PlayerTimeFirestoreDataSourceImpl(
                     .snapshots
                     .map { qs ->
                         qs.documents.mapNotNull { doc ->
-                            parsePlayerTimeDocument(doc.data<Map<String, Any?>>(), doc.id, teamDocId, matchId)
+                            try {
+                                parsePlayerTimeDocument(doc.data<Map<String, Any?>>(), matchId)
+                            } catch (_: Exception) {
+                                null
+                            }
                         }
                     }.catch { e ->
                         if (e is FirebaseFirestoreException) emit(emptyList()) else throw e
@@ -134,7 +138,11 @@ class PlayerTimeFirestoreDataSourceImpl(
                     .snapshots
                     .map { qs ->
                         qs.documents.mapNotNull { doc ->
-                            parsePlayerTimeDocument(doc.data<Map<String, Any?>>(), doc.id, teamDocId, matchId)
+                            try {
+                                parsePlayerTimeDocument(doc.data<Map<String, Any?>>(), matchId)
+                            } catch (_: Exception) {
+                                null
+                            }
                         }
                     }.catch { e ->
                         if (e is FirebaseFirestoreException) emit(emptyList()) else throw e

--- a/data/remote/src/iosMain/kotlin/com/jesuslcorominas/teamflowmanager/data/remote/datasource/PlayerTimeFirestoreDataSourceImpl.kt
+++ b/data/remote/src/iosMain/kotlin/com/jesuslcorominas/teamflowmanager/data/remote/datasource/PlayerTimeFirestoreDataSourceImpl.kt
@@ -2,6 +2,7 @@ package com.jesuslcorominas.teamflowmanager.data.remote.datasource
 
 import com.jesuslcorominas.teamflowmanager.data.core.datasource.PlayerTimeDataSource
 import com.jesuslcorominas.teamflowmanager.data.remote.firestore.PlayerTimeFirestoreModel
+import com.jesuslcorominas.teamflowmanager.data.remote.firestore.parsePlayerTimeDocument
 import com.jesuslcorominas.teamflowmanager.data.remote.firestore.toDomain
 import com.jesuslcorominas.teamflowmanager.data.remote.firestore.toFirestoreModel
 import com.jesuslcorominas.teamflowmanager.data.remote.util.toLegacyId
@@ -111,40 +112,34 @@ class PlayerTimeFirestoreDataSourceImpl(
                 return@flow
             }
             // Combine two real-time listeners: one for new String-ID docs, one for legacy Long-ID docs.
+            // Each source is mapped to a List and given its own .catch BEFORE the combine, so a
+            // failure on the legacy query does not blank out valid new-doc data (#385.3).
             // TODO: remove legacy branch after backward-compat window closes.
-            val newSnapshots =
+            val newTimes =
                 firestore.collection(PLAYER_TIMES_COLLECTION)
                     .where { "teamId" equalTo teamDocId }
                     .where { "matchId" equalTo matchId }
                     .snapshots
-            val legacySnapshots =
+                    .map { qs ->
+                        qs.documents.mapNotNull { doc ->
+                            parsePlayerTimeDocument(doc.data<Map<String, Any?>>(), doc.id, teamDocId, matchId)
+                        }
+                    }.catch { e ->
+                        if (e is FirebaseFirestoreException) emit(emptyList()) else throw e
+                    }
+            val legacyTimes =
                 firestore.collection(PLAYER_TIMES_COLLECTION)
                     .where { "teamId" equalTo teamDocId }
                     .where { "matchId" equalTo matchId.toLegacyId() }
                     .snapshots
-            emitAll(
-                combine(newSnapshots, legacySnapshots) { newQs, legacyQs ->
-                    val newTimes =
-                        newQs.documents.mapNotNull { doc ->
-                            try {
-                                doc.data<PlayerTimeFirestoreModel>().copy(matchId = matchId).toDomain()
-                            } catch (_: Exception) {
-                                null
-                            }
+                    .map { qs ->
+                        qs.documents.mapNotNull { doc ->
+                            parsePlayerTimeDocument(doc.data<Map<String, Any?>>(), doc.id, teamDocId, matchId)
                         }
-                    val legacyTimes =
-                        legacyQs.documents.mapNotNull { doc ->
-                            try {
-                                doc.data<PlayerTimeFirestoreModel>().copy(matchId = matchId).toDomain()
-                            } catch (_: Exception) {
-                                null
-                            }
-                        }
-                    newTimes + legacyTimes
-                }.catch { e ->
-                    if (e is FirebaseFirestoreException) emit(emptyList()) else throw e
-                },
-            )
+                    }.catch { e ->
+                        if (e is FirebaseFirestoreException) emit(emptyList()) else throw e
+                    }
+            emitAll(combine(newTimes, legacyTimes) { a, b -> a + b })
         }
 
     override suspend fun upsertPlayerTime(playerTime: PlayerTime) {

--- a/data/remote/src/iosMain/kotlin/com/jesuslcorominas/teamflowmanager/data/remote/datasource/PlayerTimeHistoryFirestoreDataSourceImpl.kt
+++ b/data/remote/src/iosMain/kotlin/com/jesuslcorominas/teamflowmanager/data/remote/datasource/PlayerTimeHistoryFirestoreDataSourceImpl.kt
@@ -1,8 +1,7 @@
 package com.jesuslcorominas.teamflowmanager.data.remote.datasource
 
 import com.jesuslcorominas.teamflowmanager.data.core.datasource.PlayerTimeHistoryDataSource
-import com.jesuslcorominas.teamflowmanager.data.remote.firestore.PlayerTimeHistoryFirestoreModel
-import com.jesuslcorominas.teamflowmanager.data.remote.firestore.toDomain
+import com.jesuslcorominas.teamflowmanager.data.remote.firestore.parsePlayerTimeHistoryDocument
 import com.jesuslcorominas.teamflowmanager.data.remote.firestore.toFirestoreModel
 import com.jesuslcorominas.teamflowmanager.data.remote.util.toLegacyId
 import com.jesuslcorominas.teamflowmanager.domain.model.PlayerTimeHistory
@@ -57,44 +56,38 @@ class PlayerTimeHistoryFirestoreDataSourceImpl(
                 return@flow
             }
             // Combine two real-time listeners: one for new String-ID docs, one for legacy Long-ID docs.
+            // Each source is mapped to a List and given its own .catch BEFORE the combine, so a
+            // failure on the legacy query does not blank out valid new-doc data (#385.3).
             // TODO: remove legacy branch after backward-compat window closes.
-            val newSnapshots =
+            val newHistory =
                 firestore.collection(PLAYER_TIME_HISTORY_COLLECTION)
                     .where { "teamId" equalTo teamDocId }
                     .where { "playerId" equalTo playerId }
                     .snapshots
-            val legacySnapshots =
+                    .map { qs ->
+                        qs.documents.mapNotNull { doc ->
+                            val rawData = doc.data<Map<String, Any?>>()
+                            val rawMatchId = rawData["matchId"]?.toString() ?: ""
+                            parsePlayerTimeHistoryDocument(rawData, doc.id, teamDocId, playerId, rawMatchId)
+                        }
+                    }.catch { e ->
+                        if (e is FirebaseFirestoreException) emit(emptyList()) else throw e
+                    }
+            val legacyHistory =
                 firestore.collection(PLAYER_TIME_HISTORY_COLLECTION)
                     .where { "teamId" equalTo teamDocId }
                     .where { "playerId" equalTo playerId.toLegacyId() }
                     .snapshots
-            emitAll(
-                combine(newSnapshots, legacySnapshots) { newQs, legacyQs ->
-                    val newHistory =
-                        newQs.documents.mapNotNull { doc ->
-                            try {
-                                doc.data<PlayerTimeHistoryFirestoreModel>()
-                                    .copy(id = doc.id, playerId = playerId)
-                                    .toDomain()
-                            } catch (_: Exception) {
-                                null
-                            }
+                    .map { qs ->
+                        qs.documents.mapNotNull { doc ->
+                            val rawData = doc.data<Map<String, Any?>>()
+                            val rawMatchId = rawData["matchId"]?.toString() ?: ""
+                            parsePlayerTimeHistoryDocument(rawData, doc.id, teamDocId, playerId, rawMatchId)
                         }
-                    val legacyHistory =
-                        legacyQs.documents.mapNotNull { doc ->
-                            try {
-                                doc.data<PlayerTimeHistoryFirestoreModel>()
-                                    .copy(id = doc.id, playerId = playerId)
-                                    .toDomain()
-                            } catch (_: Exception) {
-                                null
-                            }
-                        }
-                    newHistory + legacyHistory
-                }.catch { e ->
-                    if (e is FirebaseFirestoreException) emit(emptyList()) else throw e
-                },
-            )
+                    }.catch { e ->
+                        if (e is FirebaseFirestoreException) emit(emptyList()) else throw e
+                    }
+            emitAll(combine(newHistory, legacyHistory) { a, b -> a + b })
         }
 
     private suspend fun getTeamDocumentIdOrFromMatch(matchId: String): String? =
@@ -125,44 +118,38 @@ class PlayerTimeHistoryFirestoreDataSourceImpl(
                 return@flow
             }
             // Combine two real-time listeners: one for new String-ID docs, one for legacy Long-ID docs.
+            // Each source is mapped to a List and given its own .catch BEFORE the combine, so a
+            // failure on the legacy query does not blank out valid new-doc data (#385.3).
             // TODO: remove legacy branch after backward-compat window closes.
-            val newSnapshots =
+            val newHistory =
                 firestore.collection(PLAYER_TIME_HISTORY_COLLECTION)
                     .where { "teamId" equalTo teamDocId }
                     .where { "matchId" equalTo matchId }
                     .snapshots
-            val legacySnapshots =
+                    .map { qs ->
+                        qs.documents.mapNotNull { doc ->
+                            val rawData = doc.data<Map<String, Any?>>()
+                            val rawPlayerId = rawData["playerId"]?.toString() ?: ""
+                            parsePlayerTimeHistoryDocument(rawData, doc.id, teamDocId, rawPlayerId, matchId)
+                        }
+                    }.catch { e ->
+                        if (e is FirebaseFirestoreException) emit(emptyList()) else throw e
+                    }
+            val legacyHistory =
                 firestore.collection(PLAYER_TIME_HISTORY_COLLECTION)
                     .where { "teamId" equalTo teamDocId }
                     .where { "matchId" equalTo matchId.toLegacyId() }
                     .snapshots
-            emitAll(
-                combine(newSnapshots, legacySnapshots) { newQs, legacyQs ->
-                    val newHistory =
-                        newQs.documents.mapNotNull { doc ->
-                            try {
-                                doc.data<PlayerTimeHistoryFirestoreModel>()
-                                    .copy(id = doc.id, matchId = matchId)
-                                    .toDomain()
-                            } catch (_: Exception) {
-                                null
-                            }
+                    .map { qs ->
+                        qs.documents.mapNotNull { doc ->
+                            val rawData = doc.data<Map<String, Any?>>()
+                            val rawPlayerId = rawData["playerId"]?.toString() ?: ""
+                            parsePlayerTimeHistoryDocument(rawData, doc.id, teamDocId, rawPlayerId, matchId)
                         }
-                    val legacyHistory =
-                        legacyQs.documents.mapNotNull { doc ->
-                            try {
-                                doc.data<PlayerTimeHistoryFirestoreModel>()
-                                    .copy(id = doc.id, matchId = matchId)
-                                    .toDomain()
-                            } catch (_: Exception) {
-                                null
-                            }
-                        }
-                    newHistory + legacyHistory
-                }.catch { e ->
-                    if (e is FirebaseFirestoreException) emit(emptyList()) else throw e
-                },
-            )
+                    }.catch { e ->
+                        if (e is FirebaseFirestoreException) emit(emptyList()) else throw e
+                    }
+            emitAll(combine(newHistory, legacyHistory) { a, b -> a + b })
         }
 
     override fun getAllPlayerTimeHistory(): Flow<List<PlayerTimeHistory>> =
@@ -184,11 +171,10 @@ class PlayerTimeHistoryFirestoreDataSourceImpl(
             emitAll(
                 snapshots.map { qs ->
                     qs.documents.mapNotNull { doc ->
-                        try {
-                            doc.data<PlayerTimeHistoryFirestoreModel>().copy(id = doc.id).toDomain()
-                        } catch (_: Exception) {
-                            null
-                        }
+                        val rawData = doc.data<Map<String, Any?>>()
+                        val rawPlayerId = rawData["playerId"]?.toString() ?: ""
+                        val rawMatchId = rawData["matchId"]?.toString() ?: ""
+                        parsePlayerTimeHistoryDocument(rawData, doc.id, teamDocId, rawPlayerId, rawMatchId)
                     }
                 }.catch { e ->
                     if (e is FirebaseFirestoreException) emit(emptyList()) else throw e

--- a/data/remote/src/iosMain/kotlin/com/jesuslcorominas/teamflowmanager/data/remote/datasource/PlayerTimeHistoryFirestoreDataSourceImpl.kt
+++ b/data/remote/src/iosMain/kotlin/com/jesuslcorominas/teamflowmanager/data/remote/datasource/PlayerTimeHistoryFirestoreDataSourceImpl.kt
@@ -66,9 +66,13 @@ class PlayerTimeHistoryFirestoreDataSourceImpl(
                     .snapshots
                     .map { qs ->
                         qs.documents.mapNotNull { doc ->
-                            val rawData = doc.data<Map<String, Any?>>()
-                            val rawMatchId = rawData["matchId"]?.toString() ?: ""
-                            parsePlayerTimeHistoryDocument(rawData, doc.id, teamDocId, playerId, rawMatchId)
+                            try {
+                                val rawData = doc.data<Map<String, Any?>>()
+                                val rawMatchId = rawData["matchId"]?.toString() ?: ""
+                                parsePlayerTimeHistoryDocument(rawData, doc.id, playerId, rawMatchId)
+                            } catch (_: Exception) {
+                                null
+                            }
                         }
                     }.catch { e ->
                         if (e is FirebaseFirestoreException) emit(emptyList()) else throw e
@@ -80,9 +84,13 @@ class PlayerTimeHistoryFirestoreDataSourceImpl(
                     .snapshots
                     .map { qs ->
                         qs.documents.mapNotNull { doc ->
-                            val rawData = doc.data<Map<String, Any?>>()
-                            val rawMatchId = rawData["matchId"]?.toString() ?: ""
-                            parsePlayerTimeHistoryDocument(rawData, doc.id, teamDocId, playerId, rawMatchId)
+                            try {
+                                val rawData = doc.data<Map<String, Any?>>()
+                                val rawMatchId = rawData["matchId"]?.toString() ?: ""
+                                parsePlayerTimeHistoryDocument(rawData, doc.id, playerId, rawMatchId)
+                            } catch (_: Exception) {
+                                null
+                            }
                         }
                     }.catch { e ->
                         if (e is FirebaseFirestoreException) emit(emptyList()) else throw e
@@ -128,9 +136,13 @@ class PlayerTimeHistoryFirestoreDataSourceImpl(
                     .snapshots
                     .map { qs ->
                         qs.documents.mapNotNull { doc ->
-                            val rawData = doc.data<Map<String, Any?>>()
-                            val rawPlayerId = rawData["playerId"]?.toString() ?: ""
-                            parsePlayerTimeHistoryDocument(rawData, doc.id, teamDocId, rawPlayerId, matchId)
+                            try {
+                                val rawData = doc.data<Map<String, Any?>>()
+                                val rawPlayerId = rawData["playerId"]?.toString() ?: ""
+                                parsePlayerTimeHistoryDocument(rawData, doc.id, rawPlayerId, matchId)
+                            } catch (_: Exception) {
+                                null
+                            }
                         }
                     }.catch { e ->
                         if (e is FirebaseFirestoreException) emit(emptyList()) else throw e
@@ -142,9 +154,13 @@ class PlayerTimeHistoryFirestoreDataSourceImpl(
                     .snapshots
                     .map { qs ->
                         qs.documents.mapNotNull { doc ->
-                            val rawData = doc.data<Map<String, Any?>>()
-                            val rawPlayerId = rawData["playerId"]?.toString() ?: ""
-                            parsePlayerTimeHistoryDocument(rawData, doc.id, teamDocId, rawPlayerId, matchId)
+                            try {
+                                val rawData = doc.data<Map<String, Any?>>()
+                                val rawPlayerId = rawData["playerId"]?.toString() ?: ""
+                                parsePlayerTimeHistoryDocument(rawData, doc.id, rawPlayerId, matchId)
+                            } catch (_: Exception) {
+                                null
+                            }
                         }
                     }.catch { e ->
                         if (e is FirebaseFirestoreException) emit(emptyList()) else throw e
@@ -171,10 +187,14 @@ class PlayerTimeHistoryFirestoreDataSourceImpl(
             emitAll(
                 snapshots.map { qs ->
                     qs.documents.mapNotNull { doc ->
-                        val rawData = doc.data<Map<String, Any?>>()
-                        val rawPlayerId = rawData["playerId"]?.toString() ?: ""
-                        val rawMatchId = rawData["matchId"]?.toString() ?: ""
-                        parsePlayerTimeHistoryDocument(rawData, doc.id, teamDocId, rawPlayerId, rawMatchId)
+                        try {
+                            val rawData = doc.data<Map<String, Any?>>()
+                            val rawPlayerId = rawData["playerId"]?.toString() ?: ""
+                            val rawMatchId = rawData["matchId"]?.toString() ?: ""
+                            parsePlayerTimeHistoryDocument(rawData, doc.id, rawPlayerId, rawMatchId)
+                        } catch (_: Exception) {
+                            null
+                        }
                     }
                 }.catch { e ->
                     if (e is FirebaseFirestoreException) emit(emptyList()) else throw e


### PR DESCRIPTION
## Summary

**Sección A** del fix del detalle de partido del rol President (spec: [`.claude/specs/fix-president-match-detail.md`](.claude/specs/fix-president-match-detail.md)). Arregla la **capa de datos** — la ventana de compatibilidad con documentos pre-migración quedó rota tras la migración de IDs `Long → String` (#379).

## Problema

Los documentos legacy guardan los IDs cruzados (`matchId`, `scorerId`, `playerOutId`, `playerInId`, `playerId`) como `Long`, pero el modelo los declara `String`. En iOS la rama de compat deserializaba con `doc.data<Model>()` (tipado), que lanza ante el desajuste de tipos y **descarta todo el conjunto legacy** → goles/cambios/tiempos de partidos antiguos invisibles en iOS. Los agregados `getAll*` tenían el mismo problema en ambas plataformas.

## Cambios

- **Parsers puros en `commonMain`** (`LegacyDocumentParsers.kt`) como única fuente de verdad; los datasources de Android ahora delegan en ellos (elimina duplicación #385.4).
- **iOS**: los 4 datasources parsean vía `Map<String, Any?>` crudo campo a campo (tanto docs nuevos como legacy).
- **Coerción numérica `Number.toLong()`** para que valores `Int`/`Double` devueltos por GitLive no se pongan a 0 en silencio (arregla la gráfica plana, #384).
- **`.catch` por fuente antes del `combine`**: un fallo en la query legacy ya no borra los datos válidos en formato nuevo (#385.3).
- **`getAll*`** (Goal, PlayerTimeHistory) parsean vía `Map` en ambas plataformas (#385.2).

## Impacto en issues

- **Cierra #385**
- **Desbloquea #381 / #382 / #383 / #384** para partidos legacy en iOS (la causa raíz era esta). El endurecimiento de UI restante (#380, #381) va en un PR aparte (Sección B).

## Test plan

- [x] `./gradlew :data:remote:test` — 37 tests en `commonTest` (coerción Int/Double, IDs legacy `Long`, formato nuevo, `null`/vacío, status inválido)
- [x] `./gradlew :data:remote:compileKotlinIosSimulatorArm64` — compila iOS
- [x] `./gradlew ktlintCheck`
- [ ] Verificación manual en dispositivo iOS contra un partido legacy (recomendado antes de release)

## Source sets
- Parsers: `data/remote/commonMain` (sin expect/actual)
- Fixes iOS: `data/remote/iosMain` · Fix `getAll*` Android: `data/remote/androidMain` · Tests: `data/remote/commonTest`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
