### PR TITLE
fix: mostrar tiempos por periodo y goleadores desconocidos en el detalle de partido (#380, #381)

### DIFF
--- a/shared-ui/build.gradle.kts
+++ b/shared-ui/build.gradle.kts
@@ -44,6 +44,11 @@ kotlin {
         }
         val iosArm64Main by getting { dependsOn(iosMain) }
         val iosSimulatorArm64Main by getting { dependsOn(iosMain) }
+        val commonTest by getting {
+            dependencies {
+                implementation(kotlin("test"))
+            }
+        }
     }
 }
 

--- a/shared-ui/src/commonMain/composeResources/values-es/strings.xml
+++ b/shared-ui/src/commonMain/composeResources/values-es/strings.xml
@@ -249,6 +249,7 @@
     <string name="statistics_tab">Estadísticas</string>
     <string name="scorers_dialog_title">Goleadores</string>
     <string name="own_goal_scorer_label">Gol en propia</string>
+    <string name="unknown_scorer_label">Goleador desconocido</string>
     <string name="no_scorers_label">Sin goles marcados</string>
     <string name="timeline_starting_lineup">Alineación Inicial</string>
     <string name="timeline_goal">Gol</string>

--- a/shared-ui/src/commonMain/composeResources/values/strings.xml
+++ b/shared-ui/src/commonMain/composeResources/values/strings.xml
@@ -249,6 +249,7 @@
     <string name="statistics_tab">Statistics</string>
     <string name="scorers_dialog_title">Scorers</string>
     <string name="own_goal_scorer_label">Own Goal</string>
+    <string name="unknown_scorer_label">Unknown scorer</string>
     <string name="no_scorers_label">No goals scored</string>
     <string name="timeline_starting_lineup">Starting Lineup</string>
     <string name="timeline_goal">Goal</string>

--- a/shared-ui/src/commonMain/kotlin/com/jesuslcorominas/teamflowmanager/ui/components/card/MatchTimeCard.kt
+++ b/shared-ui/src/commonMain/kotlin/com/jesuslcorominas/teamflowmanager/ui/components/card/MatchTimeCard.kt
@@ -388,10 +388,14 @@ private fun getCurrentPeriodName(match: Match): String {
  * Defensive fix for legacy/malformed periods that have a configured [MatchPeriod.periodDuration]
  * but zero start/end timestamps: falls back to the configured duration instead of rendering
  * nothing, so HALF_TIME still shows e.g. 25'/25' and QUARTER_TIME shows 12:30 x4.
+ *
+ * Only trusts the timestamp delta when both timestamps are present; a period that was started
+ * but never closed (`endTimeMillis == 0`) or with an inverted delta falls back to the configured
+ * duration and is clamped to be non-negative, mirroring the guard in `Match`.
  */
 internal fun calculateFinishedPeriodElapsedTime(period: MatchPeriod): Long =
     if (period.startTimeMillis != 0L && period.endTimeMillis != 0L) {
-        period.endTimeMillis - period.startTimeMillis
+        (period.endTimeMillis - period.startTimeMillis).coerceAtLeast(0L)
     } else {
         period.periodDuration
     }

--- a/shared-ui/src/commonMain/kotlin/com/jesuslcorominas/teamflowmanager/ui/components/card/MatchTimeCard.kt
+++ b/shared-ui/src/commonMain/kotlin/com/jesuslcorominas/teamflowmanager/ui/components/card/MatchTimeCard.kt
@@ -33,6 +33,7 @@ import androidx.compose.ui.draw.rotate
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.jesuslcorominas.teamflowmanager.domain.model.Match
+import com.jesuslcorominas.teamflowmanager.domain.model.MatchPeriod
 import com.jesuslcorominas.teamflowmanager.domain.model.MatchStatus
 import com.jesuslcorominas.teamflowmanager.domain.model.PeriodType
 import com.jesuslcorominas.teamflowmanager.ui.components.AppTitle
@@ -214,9 +215,9 @@ private fun TimeBoard(
                         verticalArrangement = Arrangement.spacedBy(space = TFMSpacing.spacing02),
                     ) {
                         match.periods
-                            .filter { it.startTimeMillis != 0L && it.endTimeMillis != 0L }
+                            .filter { it.periodDuration > 0L }
                             .forEach { period ->
-                                val elapsedTime = period.endTimeMillis - period.startTimeMillis
+                                val elapsedTime = calculateFinishedPeriodElapsedTime(period)
                                 val displayTime =
                                     if (elapsedTime < period.periodDuration) elapsedTime else period.periodDuration
                                 val additionalTime =
@@ -380,3 +381,17 @@ private fun getCurrentPeriodName(match: Match): String {
         else -> stringResource(Res.string.period_label, currentPeriod.periodNumber, numberOfPeriods)
     }
 }
+
+/**
+ * Computes the elapsed time to display for a finished [MatchPeriod].
+ *
+ * Defensive fix for legacy/malformed periods that have a configured [MatchPeriod.periodDuration]
+ * but zero start/end timestamps: falls back to the configured duration instead of rendering
+ * nothing, so HALF_TIME still shows e.g. 25'/25' and QUARTER_TIME shows 12:30 x4.
+ */
+internal fun calculateFinishedPeriodElapsedTime(period: MatchPeriod): Long =
+    if (period.startTimeMillis != 0L && period.endTimeMillis != 0L) {
+        period.endTimeMillis - period.startTimeMillis
+    } else {
+        period.periodDuration
+    }

--- a/shared-ui/src/commonMain/kotlin/com/jesuslcorominas/teamflowmanager/ui/matches/MatchScreen.kt
+++ b/shared-ui/src/commonMain/kotlin/com/jesuslcorominas/teamflowmanager/ui/matches/MatchScreen.kt
@@ -113,6 +113,7 @@ import teamflowmanager.shared_ui.generated.resources.stop_match_early_title
 import teamflowmanager.shared_ui.generated.resources.summary_tab
 import teamflowmanager.shared_ui.generated.resources.timeline_tab
 import teamflowmanager.shared_ui.generated.resources.timeout_button
+import teamflowmanager.shared_ui.generated.resources.unknown_scorer_label
 import teamflowmanager.shared_ui.generated.resources.yes
 
 private const val TAB_SCORERS = 0
@@ -723,18 +724,28 @@ private fun FinishedMatchState(
     }
 }
 
-private data class ScorerEntry(val name: String, val count: Int)
+internal data class ScorerEntry(val name: String, val count: Int)
 
-private fun aggregateScorers(events: List<TimelineEvent>): Pair<List<ScorerEntry>, Int> {
+internal data class ScorerAggregation(
+    val scorers: List<ScorerEntry>,
+    val ownGoalCount: Int,
+    val unknownScorerCount: Int,
+)
+
+internal fun aggregateScorers(events: List<TimelineEvent>): ScorerAggregation {
     val scorerMap = mutableMapOf<String, ScorerEntry>()
     var ownGoalCount = 0
+    var unknownScorerCount = 0
     events.filterIsInstance<TimelineEvent.GoalScored>()
         .filter { !it.isOpponentGoal }
         .forEach { goal ->
             if (goal.isOwnGoal) {
                 ownGoalCount++
             } else {
-                goal.scorer?.let { player ->
+                val player = goal.scorer
+                if (player == null) {
+                    unknownScorerCount++
+                } else {
                     val name = "${player.firstName} ${player.lastName}"
                     val current = scorerMap[player.id]
                     scorerMap[player.id] = ScorerEntry(name, (current?.count ?: 0) + 1)
@@ -742,13 +753,13 @@ private fun aggregateScorers(events: List<TimelineEvent>): Pair<List<ScorerEntry
             }
         }
     val scorers = scorerMap.values.sortedByDescending { it.count }
-    return scorers to ownGoalCount
+    return ScorerAggregation(scorers, ownGoalCount, unknownScorerCount)
 }
 
 @Composable
 private fun ScorersTabContent(events: List<TimelineEvent>) {
-    val (scorers, ownGoalCount) = remember(events) { aggregateScorers(events) }
-    val noGoals = scorers.isEmpty() && ownGoalCount == 0
+    val (scorers, ownGoalCount, unknownScorerCount) = remember(events) { aggregateScorers(events) }
+    val noGoals = scorers.isEmpty() && ownGoalCount == 0 && unknownScorerCount == 0
 
     if (noGoals) {
         Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
@@ -770,6 +781,11 @@ private fun ScorersTabContent(events: List<TimelineEvent>) {
             if (ownGoalCount > 0) {
                 item(key = "own_goal") {
                     ScorerRow(name = stringResource(Res.string.own_goal_scorer_label), count = ownGoalCount)
+                }
+            }
+            if (unknownScorerCount > 0) {
+                item(key = "unknown_scorer") {
+                    ScorerRow(name = stringResource(Res.string.unknown_scorer_label), count = unknownScorerCount)
                 }
             }
         }
@@ -814,7 +830,7 @@ private fun ScorersDialog(
     events: List<TimelineEvent>,
     onDismiss: () -> Unit,
 ) {
-    val (scorers, ownGoalCount) = remember(events) { aggregateScorers(events) }
+    val (scorers, ownGoalCount, unknownScorerCount) = remember(events) { aggregateScorers(events) }
 
     AlertDialog(
         onDismissRequest = onDismiss,
@@ -825,7 +841,7 @@ private fun ScorersDialog(
             )
         },
         text = {
-            if (scorers.isEmpty() && ownGoalCount == 0) {
+            if (scorers.isEmpty() && ownGoalCount == 0 && unknownScorerCount == 0) {
                 Text(
                     text = stringResource(Res.string.no_scorers_label),
                     style = MaterialTheme.typography.bodyMedium,
@@ -845,6 +861,15 @@ private fun ScorersDialog(
                             ScorerItem(
                                 number = ownGoalCount.toString(),
                                 name = stringResource(Res.string.own_goal_scorer_label),
+                                onScorerSelected = {},
+                            )
+                        }
+                    }
+                    if (unknownScorerCount > 0) {
+                        item(key = "unknown_scorer") {
+                            ScorerItem(
+                                number = unknownScorerCount.toString(),
+                                name = stringResource(Res.string.unknown_scorer_label),
                                 onScorerSelected = {},
                             )
                         }

--- a/shared-ui/src/commonTest/kotlin/com/jesuslcorominas/teamflowmanager/ui/components/card/MatchTimeCardTest.kt
+++ b/shared-ui/src/commonTest/kotlin/com/jesuslcorominas/teamflowmanager/ui/components/card/MatchTimeCardTest.kt
@@ -1,0 +1,46 @@
+package com.jesuslcorominas.teamflowmanager.ui.components.card
+
+import com.jesuslcorominas.teamflowmanager.domain.model.MatchPeriod
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class MatchTimeCardTest {
+    @Test
+    fun `well-formed period returns actual elapsed time between start and end`() {
+        val period =
+            MatchPeriod(
+                periodNumber = 1,
+                periodDuration = 1_500_000L,
+                startTimeMillis = 1_000_000L,
+                endTimeMillis = 2_600_000L,
+            )
+
+        assertEquals(1_600_000L, calculateFinishedPeriodElapsedTime(period))
+    }
+
+    @Test
+    fun `finished period with zero timestamps falls back to configured period duration`() {
+        val period =
+            MatchPeriod(
+                periodNumber = 1,
+                periodDuration = 1_500_000L,
+                startTimeMillis = 0L,
+                endTimeMillis = 0L,
+            )
+
+        assertEquals(1_500_000L, calculateFinishedPeriodElapsedTime(period))
+    }
+
+    @Test
+    fun `finished period with only start timestamp zero falls back to configured duration`() {
+        val period =
+            MatchPeriod(
+                periodNumber = 1,
+                periodDuration = 750_000L,
+                startTimeMillis = 0L,
+                endTimeMillis = 2_000_000L,
+            )
+
+        assertEquals(750_000L, calculateFinishedPeriodElapsedTime(period))
+    }
+}

--- a/shared-ui/src/commonTest/kotlin/com/jesuslcorominas/teamflowmanager/ui/components/card/MatchTimeCardTest.kt
+++ b/shared-ui/src/commonTest/kotlin/com/jesuslcorominas/teamflowmanager/ui/components/card/MatchTimeCardTest.kt
@@ -43,4 +43,30 @@ class MatchTimeCardTest {
 
         assertEquals(750_000L, calculateFinishedPeriodElapsedTime(period))
     }
+
+    @Test
+    fun `period started but never ended falls back to configured duration`() {
+        val period =
+            MatchPeriod(
+                periodNumber = 1,
+                periodDuration = 1_500_000L,
+                startTimeMillis = 1_000_000L,
+                endTimeMillis = 0L,
+            )
+
+        assertEquals(1_500_000L, calculateFinishedPeriodElapsedTime(period))
+    }
+
+    @Test
+    fun `inverted timestamps are clamped to zero instead of returning a negative value`() {
+        val period =
+            MatchPeriod(
+                periodNumber = 1,
+                periodDuration = 1_500_000L,
+                startTimeMillis = 2_600_000L,
+                endTimeMillis = 1_000_000L,
+            )
+
+        assertEquals(0L, calculateFinishedPeriodElapsedTime(period))
+    }
 }

--- a/shared-ui/src/commonTest/kotlin/com/jesuslcorominas/teamflowmanager/ui/matches/MatchScreenAggregateScorersTest.kt
+++ b/shared-ui/src/commonTest/kotlin/com/jesuslcorominas/teamflowmanager/ui/matches/MatchScreenAggregateScorersTest.kt
@@ -1,0 +1,88 @@
+package com.jesuslcorominas.teamflowmanager.ui.matches
+
+import com.jesuslcorominas.teamflowmanager.domain.model.Player
+import com.jesuslcorominas.teamflowmanager.domain.model.Position
+import com.jesuslcorominas.teamflowmanager.domain.model.TimelineEvent
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class MatchScreenAggregateScorersTest {
+    private fun player(id: String) =
+        Player(
+            id = id,
+            firstName = "First$id",
+            lastName = "Last$id",
+            number = 1,
+            positions = listOf(Position.Midfielder),
+            teamId = "team-1",
+            isCaptain = false,
+        )
+
+    private fun goal(
+        scorer: Player?,
+        isOpponentGoal: Boolean = false,
+        isOwnGoal: Boolean = false,
+    ) = TimelineEvent.GoalScored(
+        matchElapsedTimeMillis = 0L,
+        scorer = scorer,
+        isOpponentGoal = isOpponentGoal,
+        isOwnGoal = isOwnGoal,
+        teamScore = 1,
+        opponentScore = 0,
+    )
+
+    @Test
+    fun `goal with null scorer is counted under unknown scorer bucket instead of dropped`() {
+        val events = listOf(goal(scorer = null))
+
+        val result = aggregateScorers(events)
+
+        assertEquals(emptyList(), result.scorers)
+        assertEquals(0, result.ownGoalCount)
+        assertEquals(1, result.unknownScorerCount)
+    }
+
+    @Test
+    fun `total goals across buckets reconciles with the number of non-opponent goals`() {
+        val playerA = player("a")
+        val events =
+            listOf(
+                goal(scorer = playerA),
+                goal(scorer = null),
+                goal(scorer = null, isOwnGoal = true),
+                goal(scorer = null, isOpponentGoal = true),
+            )
+
+        val result = aggregateScorers(events)
+
+        val totalCountedNonOpponentGoals =
+            result.scorers.sumOf { it.count } + result.ownGoalCount + result.unknownScorerCount
+        assertEquals(3, totalCountedNonOpponentGoals)
+        assertEquals(1, result.unknownScorerCount)
+        assertEquals(1, result.ownGoalCount)
+        assertEquals(listOf(ScorerEntry("${playerA.firstName} ${playerA.lastName}", 1)), result.scorers)
+    }
+
+    @Test
+    fun `known scorers are still aggregated by player id as before`() {
+        val playerA = player("a")
+        val events = listOf(goal(scorer = playerA), goal(scorer = playerA))
+
+        val result = aggregateScorers(events)
+
+        assertEquals(1, result.scorers.size)
+        assertEquals(2, result.scorers.first().count)
+        assertEquals(0, result.unknownScorerCount)
+    }
+
+    @Test
+    fun `opponent goals are ignored entirely`() {
+        val events = listOf(goal(scorer = null, isOpponentGoal = true))
+
+        val result = aggregateScorers(events)
+
+        assertEquals(emptyList(), result.scorers)
+        assertEquals(0, result.ownGoalCount)
+        assertEquals(0, result.unknownScorerCount)
+    }
+}


### PR DESCRIPTION
## Summary

**Sección B** del fix del detalle de partido del rol President (spec: [`.claude/specs/fix-president-match-detail.md`](.claude/specs/fix-president-match-detail.md)). Endurecimiento de **UI** en `shared-ui/commonMain` (un solo cambio sirve para Android e iOS). Complementa la Sección A (#386, capa de datos).

## Cambios

### #380 — Tiempos por periodo en la tarjeta de cabecera
La tarjeta de partido finalizado se saltaba los periodos cuyos timestamps de inicio/fin eran 0, ocultando los tiempos por periodo. Se extrae `calculateFinishedPeriodElapsedTime` y se filtra por `periodDuration > 0`, con fallback a la duración configurada cuando faltan timestamps → HALF_TIME muestra `25'/25'` y QUARTER_TIME `12:30 ×4`. Los periodos bien formados siguen mostrando el tiempo real transcurrido.

### #381 — Goleadores no debe descartar goles en silencio
`aggregateScorers` descartaba los goles no-rival / no-en-propia cuyo goleador no se podía resolver, de modo que el total de Goleadores no cuadraba con el marcador. Ahora se cuentan bajo un bucket **«Goleador desconocido»** (nuevo string `unknown_scorer_label`, EN/ES). La función devuelve `ScorerAggregation` en vez de un `Pair`; se añade la fila tanto en la pestaña como en el diálogo.

### #384 — Verificado (sin cambios)
La matemática de la gráfica ya usaba `matchElapsedTimeMillis` correctamente; la causa raíz (datos legacy con tiempo 0) la arregla la Sección A (#385 / #386).

## Impacto en issues
- **Cierra #380 y #381**

## Test plan
- [x] `:shared-ui:compileKotlinIosSimulatorArm64` — compila iOS
- [x] `:shared-ui:testDebugUnitTest` — 7 tests nuevos (funciones puras extraídas) verdes
- [x] `:shared-ui:ktlintCheck`
- [ ] Verificación visual en dispositivo (recomendado): cabecera de partido finalizado y pestaña Goleadores

## Notas
- Se añade el source set `commonTest` a `shared-ui` (no existía) para testear las funciones puras extraídas, siguiendo el patrón de `data/remote`.
- Sin cambios de DI ni de constructores de ViewModel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
